### PR TITLE
test: machine charm integration

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,3 +7,5 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    with:
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,5 +9,3 @@ jobs:
     secrets: inherit
     with:
       pre-run-script: tests/integration/pre_run_script.sh
-      tmate-debug: true
-      tmate-timeout: 45

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       tmate-debug: true
+      tmate-timeout: 60

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       tmate-debug: true
+      pre-run-script: tests/integration/pre-run-script.sh

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,8 +5,9 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/microk8s
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      pre-run-script: tests/integration/pre_run_script.sh
       tmate-debug: true
       tmate-timeout: 45

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/microk8s
     secrets: inherit
     with:
       tmate-debug: true
-      pre-run-script: tests/integration/pre-run-script.sh

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,4 +9,4 @@ jobs:
     secrets: inherit
     with:
       tmate-debug: true
-      tmate-timeout: 60
+      tmate-timeout: 45

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: jenkins-k8s-operator
+name: jenkins-k8s
 assumes:
   - k8s-api
 display-name: Jenkins K8s

--- a/src/agent.py
+++ b/src/agent.py
@@ -94,6 +94,6 @@ class Observer(Object):
         assert (binding := self.model.get_binding("juju-info"))  # nosec
         host = binding.network.bind_address
         event.relation.data[self.model.unit].update(
-            AgentRelationData(url=f"http://{str(host)}:{jenkins.WEB_PORT}", secret=secret)
+            AgentRelationData(url=f"http://{host}:{jenkins.WEB_PORT}", secret=secret)
         )
         self.charm.unit.status = ActiveStatus()

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -230,7 +230,7 @@ def _install_plugins(connectable_container: ops.Container) -> None:
             plugins,
         ],
         working_dir=str(WAR_PATH),
-        timeout=300,
+        timeout=600,
     )
     try:
         proc.wait_output()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,8 +3,6 @@
 
 """Fixtures for Jenkins-k8s-operator charm integration tests."""
 
-# subprocess module is required to bootstrap controllers for testing.
-import subprocess  # nosec
 import textwrap
 import typing
 from random import choices
@@ -16,7 +14,6 @@ import pytest_asyncio
 from juju.action import Action
 from juju.application import Application
 from juju.client._definitions import FullStatus, UnitStatus
-from juju.client.jujudata import FileJujuData
 from juju.model import Controller, Model
 from juju.unit import Unit
 from pytest import FixtureRequest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,6 @@
 import subprocess  # nosec
 import textwrap
 import typing
-from pathlib import Path
 from random import choices
 from string import ascii_lowercase, digits
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -141,7 +141,7 @@ async def machine_model_fixture(
     request: pytest.FixtureRequest, machine_controller: Controller
 ) -> typing.AsyncGenerator[Model, None]:
     """The machine model for jenkins agent machine charm."""
-    machine_model_name = secrets.token_hex(2)
+    machine_model_name = f"jenkins-agent-machine-{secrets.token_hex(2)}"
     model = await machine_controller.add_model(machine_model_name)
 
     yield model

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -129,7 +129,7 @@ def gen_jenkins_test_job_xml_fixture() -> typing.Callable[[str], str]:
 
 
 @pytest_asyncio.fixture(scope="module", name="machine_controller")
-async def machine_controller_fixture() -> typing.AsyncGenerator[Controller, None]:
+async def machine_controller_fixture() -> Controller:
     """The lxd controller."""
     controller = Controller()
     await controller.connect_controller("localhost")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -139,7 +139,7 @@ async def machine_controller_fixture() -> Controller:
 
 @pytest.fixture(scope="module", name="machine_model_name")
 def machine_model_name_fixture(request: pytest.FixtureRequest) -> str:
-    """The name for machine controller and model."""
+    """The name for machine model."""
     # This is taken from the same logic in pytest_operator plugin.py _generate_model_name
     # to match the ops test naming.
     module_name = request.module.__name__.rpartition(".")[-1]
@@ -151,7 +151,7 @@ def machine_model_name_fixture(request: pytest.FixtureRequest) -> str:
 async def machine_model_fixture(
     request: pytest.FixtureRequest, machine_controller: Controller, machine_model_name: str
 ) -> typing.AsyncGenerator[Model, None]:
-    """The machine model."""
+    """The machine model for jenkins agent machine charm."""
     model = await machine_controller.add_model(machine_model_name)
 
     yield model
@@ -164,11 +164,12 @@ async def machine_model_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="jenkins_machine_agent")
 async def jenkins_machine_agent_fixture(machine_model: Model) -> Application:
-    """The machine model controller."""
+    """The jenkins machine agent."""
+    # 2023-06-02 use the edge version of jenkins agent until the changes have been promoted to
+    # stable.
     app = await machine_model.deploy(
         "jenkins-agent", channel="latest/edge", config={"labels": "machine"}
     )
     await machine_model.wait_for_idle(apps=[app.name], status="blocked", timeout=1200)
-    await machine_model.create_offer(f"{app.name}:slave")
 
     return app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -203,11 +203,9 @@ async def machine_model_fixture(
 @pytest_asyncio.fixture(scope="module", name="jenkins_machine_agent")
 async def jenkins_machine_agent_fixture(machine_model: Model) -> Application:
     """The machine model controller."""
-    fixed_agent = Path(
-        "../jenkins-agent-charm/"
-        "jenkins-agent_ubuntu-16.04-amd64_ubuntu-18.04-amd64_ubuntu-20.04-amd64.charm"
+    app = await machine_model.deploy(
+        "jenkins-agent", channel="latest/edge", config={"labels": "machine"}
     )
-    app = await machine_model.deploy(fixed_agent, config={"labels": "machine"})
     await machine_model.wait_for_idle(apps=[app.name], status="blocked", timeout=1200)
     await machine_model.create_offer(f"{app.name}:slave")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,10 +3,9 @@
 
 """Fixtures for Jenkins-k8s-operator charm integration tests."""
 
+import secrets
 import textwrap
 import typing
-from random import choices
-from string import ascii_lowercase, digits
 
 import jenkinsapi.jenkins
 import pytest
@@ -137,21 +136,12 @@ async def machine_controller_fixture() -> Controller:
     return controller
 
 
-@pytest.fixture(scope="module", name="machine_model_name")
-def machine_model_name_fixture(request: pytest.FixtureRequest) -> str:
-    """The name for machine model."""
-    # This is taken from the same logic in pytest_operator plugin.py _generate_model_name
-    # to match the ops test naming.
-    module_name = request.module.__name__.rpartition(".")[-1]
-    suffix = "".join(choices(ascii_lowercase + digits, k=4))  # nosec
-    return f"{module_name.replace('_', '-')}-{suffix}"
-
-
 @pytest_asyncio.fixture(scope="module", name="machine_model")
 async def machine_model_fixture(
-    request: pytest.FixtureRequest, machine_controller: Controller, machine_model_name: str
+    request: pytest.FixtureRequest, machine_controller: Controller
 ) -> typing.AsyncGenerator[Model, None]:
     """The machine model for jenkins agent machine charm."""
+    machine_model_name = secrets.token_hex(2)
     model = await machine_controller.add_model(machine_model_name)
 
     yield model

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -157,7 +157,7 @@ async def machine_model_fixture(
     yield model
 
     if not request.config.option.keep_models:
-        await machine_controller.destroy_models(model.name, destroy_storage=True, force=True)
+        await machine_controller.destroy_models(model.name, force=True)
         # Disconnection is required for the coroutine tasks to finish.
     await model.disconnect()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,8 +23,8 @@ from pytest import FixtureRequest
 from pytest_operator.plugin import OpsTest
 
 
-@pytest_asyncio.fixture(scope="module", name="model")
-async def model_fixture(ops_test: OpsTest) -> Model:
+@pytest.fixture(scope="module", name="model")
+def model_fixture(ops_test: OpsTest) -> Model:
     """The testing model."""
     assert ops_test.model
     return ops_test.model

--- a/tests/integration/pre-run-script.sh
+++ b/tests/integration/pre-run-script.sh
@@ -1,0 +1,1 @@
+lxd init --auto

--- a/tests/integration/pre-run-script.sh
+++ b/tests/integration/pre-run-script.sh
@@ -1,1 +1,4 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 lxd init --auto

--- a/tests/integration/pre-run-script.sh
+++ b/tests/integration/pre-run-script.sh
@@ -1,7 +1,0 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-lxd init --auto
-sudo usermod -a -G microk8s runner
-sudo chown -R runner ~/.kube
-newgrp microk8s

--- a/tests/integration/pre-run-script.sh
+++ b/tests/integration/pre-run-script.sh
@@ -2,3 +2,6 @@
 # See LICENSE file for licensing details.
 
 lxd init --auto
+sudo usermod -a -G microk8s runner
+sudo chown -R runner ~/.kube
+newgrp microk8s

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Pre-run script for integration test operator-workflows action.
+# https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml
+
+# Jenkins charm is deployed on lxd and Jenkins agent charm is deployed on microk8s
+
+TESTING_MODEL="$(juju switch)"
+
+# lxd should be install and init by a previous step in integration test action.
+echo "bootstrapping lxd juju controller"
+sg microk8s -c "microk8s status --wait-ready"
+sg microk8s -c "juju bootstrap localhost localhost"
+
+echo "Switching to testing model"
+sg microk8s -c "juju switch $TESTING_MODEL"

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -6,7 +6,8 @@
 # Pre-run script for integration test operator-workflows action.
 # https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml
 
-# Jenkins machine charm is deployed on lxd and Jenkins agent charm is deployed on microk8s.
+# Jenkins machine agent charm is deployed on lxd and Jenkins-k8s server charm is deployed on
+# microk8s.
 
 TESTING_MODEL="$(juju switch)"
 

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -6,7 +6,7 @@
 # Pre-run script for integration test operator-workflows action.
 # https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml
 
-# Jenkins charm is deployed on lxd and Jenkins agent charm is deployed on microk8s
+# Jenkins machine charm is deployed on lxd and Jenkins agent charm is deployed on microk8s.
 
 TESTING_MODEL="$(juju switch)"
 

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -4,6 +4,7 @@
 """Integration tests for jenkins-k8s-operator charm."""
 
 import logging
+import typing
 from pathlib import Path
 
 import jenkinsapi.jenkins
@@ -34,7 +35,7 @@ async def test_jenkins_agent_relation(
     application: Application,
     jenkins_k8s_agent: Application,
     jenkins_client: jenkinsapi.jenkins.Jenkins,
-    jenkins_test_job_xml: str,
+    gen_jenkins_test_job_xml: str,
 ):
     """
     arrange: given jenkins-k8s-agent and jenkins server charms.
@@ -49,7 +50,7 @@ async def test_jenkins_agent_relation(
         ("jenkins-agent-k8s-0" in key for key in nodes.keys())
     ), "Jenkins k8s agent node not registered."
 
-    job = jenkins_client.create_job("test", jenkins_test_job_xml)
+    job = jenkins_client.create_job("test", gen_jenkins_test_job_xml("k8s"))
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()
@@ -61,7 +62,7 @@ async def test_jenkins_machine_agent_relation(
     jenkins_machine_agent: Application,
     application: Application,
     jenkins_client: jenkinsapi.jenkins.Jenkins,
-    jenkins_test_job_xml: str,
+    gen_jenkins_test_job_xml: typing.Callable[[str], str],
 ):
     """
     arrange: given a cross controller cross model jenkins machine agent with an offer.
@@ -80,7 +81,7 @@ async def test_jenkins_machine_agent_relation(
         ("jenkins-agent-0" in key for key in nodes.keys())
     ), "Jenkins agent node not registered."
 
-    job = jenkins_client.create_job("test", jenkins_test_job_xml)
+    job = jenkins_client.create_job("test", gen_jenkins_test_job_xml("machine"))
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -35,7 +35,7 @@ async def test_jenkins_agent_relation(
     application: Application,
     jenkins_k8s_agent: Application,
     jenkins_client: jenkinsapi.jenkins.Jenkins,
-    gen_jenkins_test_job_xml: str,
+    gen_jenkins_test_job_xml: typing.Callable[[str], str],
 ):
     """
     arrange: given jenkins-k8s-agent and jenkins server charms.

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -58,21 +58,22 @@ async def test_jenkins_agent_relation(
 
 
 async def test_jenkins_machine_agent_relation(
-    model: Model,
     jenkins_machine_agent: Application,
     application: Application,
     jenkins_client: jenkinsapi.jenkins.Jenkins,
     gen_jenkins_test_job_xml: typing.Callable[[str], str],
 ):
     """
-    arrange: given a cross controller cross model jenkins machine agent with an offer.
-    act: when the relation is setup through an offer.
+    arrange: given a cross controller cross model jenkins machine agent.
+    act: when the offer is created and relation is setup through the offer.
     assert: the relation succeeds and the agent is able to run jobs successfully.
     """
-    model_name = jenkins_machine_agent.model.name
+    machine_model: Model = jenkins_machine_agent.model
+    await machine_model.create_offer(f"{jenkins_machine_agent.name}:slave")
+    model: Model = application.model
     await model.relate(
         f"{application.name}:agent",
-        f"localhost:admin/{model_name}.{jenkins_machine_agent.name}",
+        f"localhost:admin/{machine_model.name}.{jenkins_machine_agent.name}",
     )
     await model.wait_for_idle(status="active", timeout=1200)
 

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -69,10 +69,10 @@ async def test_jenkins_machine_agent_relation(
     act: when the relation is setup through an offer.
     assert: the relation succeeds and the agent is able to run jobs successfully.
     """
-    controller_name = model_name = jenkins_machine_agent.model.name
+    model_name = jenkins_machine_agent.model.name
     await model.relate(
         f"{application.name}:agent",
-        f"{controller_name}:admin/{model_name}.{jenkins_machine_agent.name}",
+        f"localhost:admin/{model_name}.{jenkins_machine_agent.name}",
     )
     await model.wait_for_idle(status="active", timeout=1200)
 


### PR DESCRIPTION
This PR adds a Cross-Model Cross Controller integration test with the Jenkins agent machine charm.

Other changes:
- remove duplicate str conversion
- increase plugins install timeout
- rename to jenkins-k8s from jenkins-k8s-operator

<img width="729" alt="image" src="https://github.com/canonical/jenkins-k8s-operator/assets/37652070/b6b312a4-dbef-4c31-ab1f-002357b3fcca">
