### PR TITLE
feat: new agent_v0_interface support

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -38,7 +38,7 @@ resources:
     type: oci-image
     description: OCI image for Jenkins
 requires:
-  slave:
+  agent-deprecated:
     interface: jenkins-slave
     optional: true
   agent:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -38,6 +38,9 @@ resources:
     type: oci-image
     description: OCI image for Jenkins
 requires:
-  agent:
+  slave:
     interface: jenkins-slave
+    optional: true
+  agent:
+    interface: jenkins_agent_v0
     optional: true

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -5,6 +5,10 @@
 # <kbd>module</kbd> `agent.py`
 The Jenkins agent relation observer. 
 
+**Global Variables**
+---------------
+- **AGENT_RELATION**
+- **SLAVE_RELATION**
 
 
 ---
@@ -28,7 +32,7 @@ Relation data required for adding the Jenkins agent.
 ## <kbd>class</kbd> `Observer`
 The Jenkins agent relation observer. 
 
-<a href="../src/agent.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/agent.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -8,7 +8,7 @@ The Jenkins agent relation observer.
 **Global Variables**
 ---------------
 - **AGENT_RELATION**
-- **SLAVE_RELATION**
+- **DEPRECATED_AGENT_RELATION**
 
 
 ---

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -26,7 +26,7 @@ Initialize the charm and register event handlers.
 
 **Args:**
  
- - <b>`args`</b>:  Arguments to initialize the char base. 
+ - <b>`args`</b>:  Arguments to initialize the charm base. 
 
 
 ---

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -29,6 +29,12 @@ Initialize the charm and register event handlers.
  - <b>`args`</b>:  Arguments to initialize the charm base. 
 
 
+
+**Raises:**
+ 
+ - <b>`RuntimeError`</b>:  if invalid state value was encountered from relation. 
+
+
 ---
 
 #### <kbd>property</kbd> app

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -204,7 +204,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L499"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L522"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_updatable_version`
 
@@ -228,7 +228,7 @@ Get version to update to if available.
 
 ---
 
-<a href="../src/jenkins.py#L525"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L548"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `download_stable_war`
 
@@ -254,7 +254,7 @@ Download and replace the war executable.
 
 ---
 
-<a href="../src/jenkins.py#L585"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L608"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -280,6 +280,55 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
+<a href="../src/jenkins.py#L636"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_agent_name`
+
+```python
+get_agent_name(unit_name: str) → str
+```
+
+Infer agent name from unit name. 
+
+
+
+**Args:**
+ 
+ - <b>`unit_name`</b>:  The agent unit name. 
+
+
+
+**Returns:**
+ The agent node name registered on Jenkins server. 
+
+
+---
+
+<a href="../src/jenkins.py#L648"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `remove_agent_node`
+
+```python
+remove_agent_node(
+    agent_name: str,
+    credentials: Credentials,
+    client: Jenkins | None = None
+) → None
+```
+
+Remove registered agent from Jenkins server. 
+
+
+
+**Args:**
+ 
+ - <b>`agent_name`</b>:  The agent name to remove. 
+ - <b>`credentials`</b>:  The credentials of a Jenkins user with access to the Jenkins API. 
+ - <b>`client`</b>:  The API client used to communicate with the Jenkins server. 
+
+
+---
+
 ## <kbd>class</kbd> `AgentMeta`
 Metadata for registering Jenkins Agent. 
 
@@ -289,7 +338,7 @@ Metadata for registering Jenkins Agent.
  
  - <b>`executors`</b>:  Number of executors of the agent in string format. 
  - <b>`labels`</b>:  Comma separated list of labels to be assigned to the agent. 
- - <b>`slavehost`</b>:  The host name of the agent. 
+ - <b>`name`</b>:  The host name of the agent. 
 
 
 

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -51,7 +51,7 @@ Wait until Jenkins service is up.
 ## <kbd>function</kbd> `get_admin_credentials`
 
 ```python
-get_admin_credentials(connectable_container: Container) → Credentials
+get_admin_credentials(container: Container) → Credentials
 ```
 
 Retrieve admin credentials. 
@@ -60,7 +60,7 @@ Retrieve admin credentials.
 
 **Args:**
  
- - <b>`connectable_container`</b>:  Connectable container to interact with filesystem. 
+ - <b>`container`</b>:  The Jenkins workload container to interact with filesystem. 
 
 
 
@@ -70,7 +70,7 @@ Retrieve admin credentials.
 
 ---
 
-<a href="../src/jenkins.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `calculate_env`
 
@@ -88,7 +88,7 @@ Return a dictionary for Jenkins Pebble layer.
 
 ---
 
-<a href="../src/jenkins.py#L194"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_version`
 
@@ -112,12 +112,12 @@ Get the Jenkins server version.
 
 ---
 
-<a href="../src/jenkins.py#L288"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L284"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `bootstrap`
 
 ```python
-bootstrap(connectable_container: Container) → None
+bootstrap(container: Container) → None
 ```
 
 Initialize and install Jenkins. 
@@ -126,7 +126,7 @@ Initialize and install Jenkins.
 
 **Args:**
  
- - <b>`connectable_container`</b>:  The connectable Jenkins workload container. 
+ - <b>`container`</b>:  The Jenkins workload container. 
 
 
 
@@ -137,14 +137,14 @@ Initialize and install Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L320"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_node_secret`
 
 ```python
 get_node_secret(
     node_name: str,
-    credentials: Credentials,
+    container: Container,
     client: Jenkins | None = None
 ) → str
 ```
@@ -156,7 +156,7 @@ Get node secret from jenkins.
 **Args:**
  
  - <b>`node_name`</b>:  The registered node to fetch the secret from. 
- - <b>`credentials`</b>:  The credentials of a Jenkins user with access to the Jenkins API. 
+ - <b>`container`</b>:  The Jenkins workload container. 
  - <b>`client`</b>:  The API client used to communicate with the Jenkins server. 
 
 
@@ -173,14 +173,14 @@ Get node secret from jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L352"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L348"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `add_agent_node`
 
 ```python
 add_agent_node(
     agent_meta: AgentMeta,
-    credentials: Credentials,
+    container: Container,
     client: Jenkins | None = None
 ) → None
 ```
@@ -192,7 +192,7 @@ Add a Jenkins agent node.
 **Args:**
  
  - <b>`agent_meta`</b>:  The Jenkins agent metadata to create the node from. 
- - <b>`credentials`</b>:  The credentials of a Jenkins user with access to the Jenkins API. 
+ - <b>`container`</b>:  The Jenkins workload container. 
  - <b>`client`</b>:  The API client used to communicate with the Jenkins server. 
 
 
@@ -204,7 +204,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L382"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L378"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_agent_node`
 
@@ -235,7 +235,7 @@ Remove a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L488"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L484"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_updatable_version`
 
@@ -259,12 +259,12 @@ Get version to update to if available.
 
 ---
 
-<a href="../src/jenkins.py#L514"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L510"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `download_stable_war`
 
 ```python
-download_stable_war(connectable_container: Container, version: str) → None
+download_stable_war(container: Container, version: str) → None
 ```
 
 Download and replace the war executable. 
@@ -273,7 +273,7 @@ Download and replace the war executable.
 
 **Args:**
  
- - <b>`connectable_container`</b>:  The Jenkins container with jenkins.war executable. 
+ - <b>`container`</b>:  The Jenkins container with jenkins.war executable. 
  - <b>`version`</b>:  Desired version of the war to download. 
 
 
@@ -285,7 +285,7 @@ Download and replace the war executable.
 
 ---
 
-<a href="../src/jenkins.py#L574"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L570"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -311,7 +311,7 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
-<a href="../src/jenkins.py#L602"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L598"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_agent_name`
 

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -204,6 +204,37 @@ Add a Jenkins agent node.
 
 ---
 
+<a href="../src/jenkins.py#L416"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `remove_agent_node`
+
+```python
+remove_agent_node(
+    agent_name: str,
+    credentials: Credentials,
+    client: Jenkins | None = None
+) → None
+```
+
+Remove a Jenkins agent node. 
+
+
+
+**Args:**
+ 
+ - <b>`agent_name`</b>:  The agent node name to remove. 
+ - <b>`credentials`</b>:  The credentials of a Jenkins user with access to the Jenkins API. 
+ - <b>`client`</b>:  The API client used to communicate with the Jenkins server. 
+
+
+
+**Raises:**
+ 
+ - <b>`JenkinsError`</b>:  if an error occurred running groovy script removing the node. 
+
+
+---
+
 <a href="../src/jenkins.py#L522"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_updatable_version`
@@ -300,31 +331,6 @@ Infer agent name from unit name.
 
 **Returns:**
  The agent node name registered on Jenkins server. 
-
-
----
-
-<a href="../src/jenkins.py#L648"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>function</kbd> `remove_agent_node`
-
-```python
-remove_agent_node(
-    agent_name: str,
-    credentials: Credentials,
-    client: Jenkins | None = None
-) → None
-```
-
-Remove registered agent from Jenkins server. 
-
-
-
-**Args:**
- 
- - <b>`agent_name`</b>:  The agent name to remove. 
- - <b>`credentials`</b>:  The credentials of a Jenkins user with access to the Jenkins API. 
- - <b>`client`</b>:  The API client used to communicate with the Jenkins server. 
 
 
 ---

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -20,7 +20,7 @@ Functions to operate Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `wait_ready`
 
@@ -46,7 +46,7 @@ Wait until Jenkins service is up.
 
 ---
 
-<a href="../src/jenkins.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_admin_credentials`
 
@@ -70,7 +70,7 @@ Retrieve admin credentials.
 
 ---
 
-<a href="../src/jenkins.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `calculate_env`
 
@@ -88,7 +88,7 @@ Return a dictionary for Jenkins Pebble layer.
 
 ---
 
-<a href="../src/jenkins.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L194"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_version`
 
@@ -112,7 +112,7 @@ Get the Jenkins server version.
 
 ---
 
-<a href="../src/jenkins.py#L322"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L288"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `bootstrap`
 
@@ -137,7 +137,7 @@ Initialize and install Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L358"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_node_secret`
 
@@ -173,7 +173,7 @@ Get node secret from jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L386"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L352"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `add_agent_node`
 
@@ -204,7 +204,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L416"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L382"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_agent_node`
 
@@ -235,7 +235,7 @@ Remove a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L522"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L488"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_updatable_version`
 
@@ -259,7 +259,7 @@ Get version to update to if available.
 
 ---
 
-<a href="../src/jenkins.py#L548"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L514"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `download_stable_war`
 
@@ -285,7 +285,7 @@ Download and replace the war executable.
 
 ---
 
-<a href="../src/jenkins.py#L608"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L574"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -311,7 +311,7 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
-<a href="../src/jenkins.py#L636"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L602"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_agent_name`
 
@@ -331,41 +331,6 @@ Infer agent name from unit name.
 
 **Returns:**
  The agent node name registered on Jenkins server. 
-
-
----
-
-## <kbd>class</kbd> `AgentMeta`
-Metadata for registering Jenkins Agent. 
-
-
-
-**Attributes:**
- 
- - <b>`executors`</b>:  Number of executors of the agent in string format. 
- - <b>`labels`</b>:  Comma separated list of labels to be assigned to the agent. 
- - <b>`name`</b>:  The host name of the agent. 
-
-
-
-
----
-
-<a href="../src/jenkins.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `validate`
-
-```python
-validate() → None
-```
-
-Validate the agent metadata. 
-
-
-
-**Raises:**
- 
- - <b>`ValidationError`</b>:  if the field contains invalid data. 
 
 
 ---

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -8,7 +8,7 @@ Jenkins States.
 **Global Variables**
 ---------------
 - **AGENT_RELATION**
-- **SLAVE_RELATION**
+- **DEPRECATED_AGENT_RELATION**
 
 
 ---

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -5,6 +5,10 @@
 # <kbd>module</kbd> `state.py`
 Jenkins States. 
 
+**Global Variables**
+---------------
+- **AGENT_RELATION**
+- **SLAVE_RELATION**
 
 
 ---
@@ -18,7 +22,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -64,7 +68,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -191,7 +191,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L177"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -13,6 +13,96 @@ Jenkins States.
 
 ---
 
+## <kbd>class</kbd> `AgentMeta`
+Metadata for registering Jenkins Agent. 
+
+
+
+**Attributes:**
+ 
+ - <b>`executors`</b>:  Number of executors of the agent in string format. 
+ - <b>`labels`</b>:  Comma separated list of labels to be assigned to the agent. 
+ - <b>`name`</b>:  The host name of the agent. 
+
+
+
+
+---
+
+<a href="../src/state.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_agent_relation`
+
+```python
+from_agent_relation(
+    relation_data: RelationDataContent
+) → Optional[ForwardRef('AgentMeta')]
+```
+
+Instantiate AgentMeta from charm relation databag. 
+
+
+
+**Args:**
+ 
+ - <b>`relation_data`</b>:  The unit relation databag. 
+
+
+
+**Returns:**
+ AgentMeta if complete values(executors, labels, slavehost) are set. None otherwise. 
+
+---
+
+<a href="../src/state.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_deprecated_agent_relation`
+
+```python
+from_deprecated_agent_relation(
+    relation_data: RelationDataContent
+) → Optional[ForwardRef('AgentMeta')]
+```
+
+Instantiate AgentMeta from charm relation databag. 
+
+
+
+**Args:**
+ 
+ - <b>`relation_data`</b>:  The unit relation databag. 
+
+
+
+**Returns:**
+ AgentMeta if complete values(executors, labels, slavehost) are set. None otherwise. 
+
+---
+
+<a href="../src/state.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `numeric_executors`
+
+```python
+numeric_executors(value: str) → int
+```
+
+Validate executors field can be converted to int. 
+
+
+
+**Args:**
+ 
+ - <b>`value`</b>:  The value of executors field. 
+
+
+
+**Returns:**
+ Coerced numerical value of executors. 
+
+
+---
+
 ## <kbd>class</kbd> `CharmConfigInvalidError`
 Exception raised when a charm configuration is found to be invalid. 
 
@@ -22,7 +112,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -31,6 +121,37 @@ __init__(msg: str)
 ```
 
 Initialize a new instance of the CharmConfigInvalidError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `CharmRelationDataInvalidError`
+Represents an error with invalid data in relation data. 
+
+
+
+**Attributes:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+<a href="../src/state.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Initialize a new instance of the CharmRelationDataInvalidError exception. 
 
 
 
@@ -60,15 +181,17 @@ The Jenkins k8s operator charm state.
 
 **Attributes:**
  
- - <b>`jenkins_service_name`</b>:  The Jenkins service name. Note that the container name is the same. 
  - <b>`update_time_range`</b>:  Time range to allow Jenkins to update version. 
+ - <b>`agent_relation_meta`</b>:  Metadata of all agents from units related through agent relation. 
+ - <b>`deprecated_agent_relation_meta`</b>:  Metadata of all agents from units related through  deprecated agent relation. 
+ - <b>`jenkins_service_name`</b>:  The Jenkins service name. Note that the container name is the same. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -94,5 +217,6 @@ Initialize the state from charm.
 **Raises:**
  
  - <b>`CharmConfigInvalidError`</b>:  if invalid state values were encountered. 
+ - <b>`CharmRelationDataInvalidError`</b>:  if invalid relation data was received. 
 
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -146,6 +146,7 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
         if not container.can_connect():
+            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -174,6 +175,7 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
         if not container.can_connect():
+            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -8,7 +8,7 @@ import typing
 import ops
 
 import jenkins
-from state import AGENT_RELATION, SLAVE_RELATION, State
+from state import AGENT_RELATION, DEPRECATED_AGENT_RELATION, State
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +40,12 @@ class Observer(ops.Object):
         self.state = state
 
         charm.framework.observe(
-            charm.on[SLAVE_RELATION].relation_joined, self._on_slave_relation_joined
+            charm.on[DEPRECATED_AGENT_RELATION].relation_joined,
+            self._on_deprecated_agent_relation_joined,
         )
         charm.framework.observe(
-            charm.on[SLAVE_RELATION].relation_departed, self._on_slave_relation_departed
+            charm.on[DEPRECATED_AGENT_RELATION].relation_departed,
+            self._on_deprecated_agent_relation_departed,
         )
         charm.framework.observe(
             charm.on[AGENT_RELATION].relation_joined, self._on_agent_relation_joined
@@ -52,8 +54,8 @@ class Observer(ops.Object):
             charm.on[AGENT_RELATION].relation_departed, self._on_agent_relation_departed
         )
 
-    def _on_slave_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
-        """Handle slave relation joined event.
+    def _on_deprecated_agent_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
+        """Handle deprecated agent relation joined event.
 
         Args:
             event: The event fired from an agent joining the relationship.
@@ -153,11 +155,11 @@ class Observer(ops.Object):
         )
         self.charm.unit.status = ops.ActiveStatus()
 
-    def _on_slave_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
-        """Handle slave relation departed event.
+    def _on_deprecated_agent_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
+        """Handle deprecated agent relation departed event.
 
         Args:
-            event: The event fired when a unit in slave relation is departed.
+            event: The event fired when a unit in deprecated agent relation is departed.
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
@@ -182,10 +184,10 @@ class Observer(ops.Object):
         self.charm.unit.status = ops.ActiveStatus()
 
     def _on_agent_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
-        """Handle slave relation departed event.
+        """Handle agent relation departed event.
 
         Args:
-            event: The event fired when a unit in slave relation is departed.
+            event: The event fired when a unit in agent relation is departed.
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)

--- a/src/agent.py
+++ b/src/agent.py
@@ -76,13 +76,12 @@ class Observer(ops.Object):
             return
 
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
-        credentials = jenkins.get_admin_credentials(container)
         try:
             jenkins.add_agent_node(
                 agent_meta=agent_meta,
-                credentials=credentials,
+                container=container,
             )
-            secret = jenkins.get_node_secret(credentials=credentials, node_name=agent_meta.name)
+            secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
@@ -117,13 +116,12 @@ class Observer(ops.Object):
             return
 
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
-        credentials = jenkins.get_admin_credentials(container)
         try:
             jenkins.add_agent_node(
                 agent_meta=agent_meta,
-                credentials=credentials,
+                container=container,
             )
-            secret = jenkins.get_node_secret(credentials=credentials, node_name=agent_meta.name)
+            secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return

--- a/src/agent.py
+++ b/src/agent.py
@@ -10,7 +10,7 @@ from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus
 
 import jenkins
-from state import State
+from state import AGENT_RELATION, SLAVE_RELATION, State
 
 logger = logging.getLogger(__name__)
 
@@ -41,15 +41,20 @@ class Observer(Object):
         self.charm = charm
         self.state = state
 
-        charm.framework.observe(charm.on["agent"].relation_joined, self._on_agent_relation_joined)
+        charm.framework.observe(
+            charm.on[SLAVE_RELATION].relation_joined, self._on_slave_relation_joined
+        )
+        charm.framework.observe(
+            charm.on[AGENT_RELATION].relation_joined, self._on_agent_relation_joined
+        )
 
     @property
     def _jenkins_container(self) -> Container:
         """The Jenkins workload container."""
         return self.charm.unit.get_container(self.state.jenkins_service_name)
 
-    def _on_agent_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Handle agent relation joined event.
+    def _on_slave_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Handle slave relation joined event.
 
         Args:
             event: The event fired from an agent joining the relationship.
@@ -67,7 +72,7 @@ class Observer(Object):
         agent_meta = jenkins.AgentMeta(
             executors=event.relation.data[event.unit]["executors"],
             labels=event.relation.data[event.unit]["labels"],
-            slavehost=event.relation.data[event.unit]["slavehost"],
+            name=event.relation.data[event.unit]["slavehost"],
         )
         try:
             agent_meta.validate()
@@ -83,9 +88,7 @@ class Observer(Object):
                 agent_meta=agent_meta,
                 credentials=credentials,
             )
-            secret = jenkins.get_node_secret(
-                credentials=credentials, node_name=agent_meta.slavehost
-            )
+            secret = jenkins.get_node_secret(credentials=credentials, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
@@ -95,5 +98,56 @@ class Observer(Object):
         host = binding.network.bind_address
         event.relation.data[self.model.unit].update(
             AgentRelationData(url=f"http://{host}:{jenkins.WEB_PORT}", secret=secret)
+        )
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_agent_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Handle agent relation joined event.
+
+        Args:
+            event: The event fired from an agent joining the relationship.
+        """
+        if not self._jenkins_container.can_connect():
+            event.defer()
+            return
+        if not event.unit or not all(
+            event.relation.data[event.unit].get(required_data)
+            for required_data in ("executors", "labels", "name")
+        ):
+            logger.warning("Relation data not ready yet. Deferring.")
+            event.defer()
+            return
+        agent_meta = jenkins.AgentMeta(
+            executors=event.relation.data[event.unit]["executors"],
+            labels=event.relation.data[event.unit]["labels"],
+            name=event.relation.data[event.unit]["name"],
+        )
+        try:
+            agent_meta.validate()
+        except jenkins.ValidationError as exc:
+            logger.error("Invalid agent relation data. %s", exc)
+            self.charm.unit.status = BlockedStatus("Invalid agent relation data.")
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Adding agent node.")
+        credentials = jenkins.get_admin_credentials(self._jenkins_container)
+        try:
+            jenkins.add_agent_node(
+                agent_meta=agent_meta,
+                credentials=credentials,
+            )
+            secret = jenkins.get_node_secret(credentials=credentials, node_name=agent_meta.name)
+        except jenkins.JenkinsError as exc:
+            self.charm.unit.status = BlockedStatus(f"Jenkins API exception. {exc=!r}")
+            return
+
+        # This is to avoid the None type.
+        assert (binding := self.model.get_binding("juju-info"))  # nosec
+        host = binding.network.bind_address
+        event.relation.data[self.model.unit].update(
+            {
+                "url": f"http://{host}:{jenkins.WEB_PORT}",
+                f"{agent_meta.name}_secret": secret,
+            }
         )
         self.charm.unit.status = ActiveStatus()

--- a/src/agent.py
+++ b/src/agent.py
@@ -164,7 +164,11 @@ class Observer(ops.Object):
         if not container.can_connect():
             return
 
-        agent_name = event.relation.data[typing.cast(ops.Unit, event.unit)]["slavehost"]
+        # The relation data is removed before this particular hook runs, making the name set by the
+        # agent not available. Hence, we can try to infer the name of the unit.
+        # See discussion: https://github.com/canonical/operator/issues/888
+        # assert type since event unit cannot be None.
+        agent_name = jenkins.get_agent_name(typing.cast(ops.Unit, event.unit).name)
         credentials = jenkins.get_admin_credentials(container)
         self.charm.unit.status = ops.MaintenanceStatus("Removing agent node.")
         try:
@@ -188,7 +192,11 @@ class Observer(ops.Object):
         if not container.can_connect():
             return
 
-        agent_name = event.relation.data[typing.cast(ops.Unit, event.unit)]["name"]
+        # The relation data is removed before this particular hook runs, making the name set by the
+        # agent not available. Hence, we can try to infer the name of the unit.
+        # See discussion: https://github.com/canonical/operator/issues/888
+        # assert type since event unit cannot be None.
+        agent_name = jenkins.get_agent_name(typing.cast(ops.Unit, event.unit).name)
         credentials = jenkins.get_admin_credentials(container)
         self.charm.unit.status = ops.MaintenanceStatus("Removing agent node.")
         try:

--- a/src/agent.py
+++ b/src/agent.py
@@ -150,3 +150,38 @@ class Observer(ops.Object):
         )
         self.charm.unit.status = ops.ActiveStatus()
 
+    def _on_slave_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
+        """Handle slave relation departed event.
+
+        Args:
+            event: The event fired when a unit in slave relation is departed.
+        """
+        agent_name = event.relation.data[self.model.unit]["slavehost"]
+        self.charm.unit.status = ops.MaintenanceStatus("Removing agent node.")
+        try:
+            jenkins.remove_agent_node(agent_name=agent_name)
+        except jenkins.JenkinsError as exc:
+            logger.error("Failed to remove agent %s, %s", agent_name, exc)
+            # There is no support for degraded status yet, however, this will not impact Jenkins
+            # server operation.
+            self.charm.unit.status = ops.ActiveStatus()
+            return
+        self.charm.unit.status = ops.ActiveStatus()
+
+    def _on_agent_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
+        """Handle slave relation departed event.
+
+        Args:
+            event: The event fired when a unit in slave relation is departed.
+        """
+        agent_name = event.relation.data[self.model.unit]["name"]
+        self.charm.unit.status = ops.MaintenanceStatus("Removing agent node.")
+        try:
+            jenkins.remove_agent_node(agent_name=agent_name)
+        except jenkins.JenkinsError as exc:
+            logger.error("Failed to remove agent %s, %s", agent_name, exc)
+            # There is no support for degraded status yet, however, this will not impact Jenkins
+            # server operation.
+            self.charm.unit.status = ops.ActiveStatus()
+            return
+        self.charm.unit.status = ops.ActiveStatus()

--- a/src/agent.py
+++ b/src/agent.py
@@ -66,10 +66,10 @@ class Observer(ops.Object):
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
-            typing.Mapping[ops.Unit, AgentMeta], self.state.deprecated_agent_relation_meta
+            typing.Mapping[str, AgentMeta], self.state.deprecated_agent_relation_meta
         )
         # The event unit cannot be None.
-        agent_meta = deprecated_agent_relation_meta[typing.cast(ops.Unit, event.unit)]
+        agent_meta = deprecated_agent_relation_meta[typing.cast(ops.Unit, event.unit).name]
         if not agent_meta:
             logger.warning("Relation data not ready yet. Deferring.")
             event.defer()
@@ -106,10 +106,10 @@ class Observer(ops.Object):
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
-            typing.Mapping[ops.Unit, AgentMeta], self.state.agent_relation_meta
+            typing.Mapping[str, AgentMeta], self.state.agent_relation_meta
         )
         # The event unit cannot be None.
-        agent_meta = agent_relation_meta[typing.cast(ops.Unit, event.unit)]
+        agent_meta = agent_relation_meta[typing.cast(ops.Unit, event.unit).name]
         if not agent_meta:
             logger.warning("Relation data not ready yet. Deferring.")
             event.defer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ from ops.pebble import Layer
 
 import agent
 import jenkins
-from state import CharmConfigInvalidError, State
+from state import CharmConfigInvalidError, CharmRelationDataInvalidError, State
 
 if typing.TYPE_CHECKING:
     from ops.pebble import LayerDict  # pragma: no cover
@@ -32,6 +32,9 @@ class JenkinsK8sOperatorCharm(CharmBase):
 
         Args:
             args: Arguments to initialize the charm base.
+
+        Raises:
+            RuntimeError: if invalid state value was encountered from relation.
         """
         super().__init__(*args)
         try:
@@ -39,6 +42,8 @@ class JenkinsK8sOperatorCharm(CharmBase):
         except CharmConfigInvalidError as exc:
             self.unit.status = BlockedStatus(exc.msg)
             return
+        except CharmRelationDataInvalidError as exc:
+            raise RuntimeError("Invalid relation data received.") from exc
 
         self.agent_observer = agent.Observer(self, self.state)
         self.framework.observe(self.on.jenkins_pebble_ready, self._on_jenkins_pebble_ready)

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,7 +31,7 @@ class JenkinsK8sOperatorCharm(CharmBase):
         """Initialize the charm and register event handlers.
 
         Args:
-            args: Arguments to initialize the char base.
+            args: Arguments to initialize the charm base.
         """
         super().__init__(*args)
         try:

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -413,6 +413,29 @@ def add_agent_node(
         raise JenkinsError("Failed to add agent node.") from exc
 
 
+def remove_agent_node(
+    agent_name: str,
+    credentials: Credentials,
+    client: jenkinsapi.jenkins.Jenkins | None = None,
+) -> None:
+    """Remove a Jenkins agent node.
+
+    Args:
+        agent_name: The agent node name to remove.
+        credentials: The credentials of a Jenkins user with access to the Jenkins API.
+        client: The API client used to communicate with the Jenkins server.
+
+    Raises:
+        JenkinsError: if an error occurred running groovy script removing the node.
+    """
+    client = client if client is not None else _get_client(credentials)
+    try:
+        client.delete_node(nodename=agent_name)
+    except jenkinsapi.custom_exceptions.JenkinsAPIException as exc:
+        logger.error("Failed to delete agent node, %s", exc)
+        raise JenkinsError("Failed to delete agent node.") from exc
+
+
 def _get_major_minor_version(version: str) -> str:
     """Extract the major.minor version from semantic version string.
 

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -20,6 +20,8 @@ import jenkinsapi.jenkins
 import ops
 import requests
 
+import state
+
 logger = logging.getLogger(__name__)
 
 WEB_PORT = 8080
@@ -81,42 +83,6 @@ class JenkinsNetworkError(JenkinsError):
 
 class JenkinsUpdateError(JenkinsError):
     """An error occurred trying to update Jenkins."""
-
-
-@dataclasses.dataclass(frozen=True)
-class AgentMeta:
-    """Metadata for registering Jenkins Agent.
-
-    Attributes:
-        executors: Number of executors of the agent in string format.
-        labels: Comma separated list of labels to be assigned to the agent.
-        name: The host name of the agent.
-    """
-
-    executors: str
-    labels: str
-    name: str
-
-    def validate(self) -> None:
-        """Validate the agent metadata.
-
-        Raises:
-            ValidationError: if the field contains invalid data.
-        """
-        empty_fields = [
-            field
-            # Pylint doesn't understand that __annotations__ is implemented in a Python class.
-            for field in self.__annotations__.keys()  # pylint: disable=no-member
-            if not getattr(self, field)
-        ]
-        if empty_fields:
-            raise ValidationError(f"Fields {empty_fields} cannot be empty.")
-        try:
-            int(self.executors)
-        except ValueError as exc:
-            raise ValidationError(
-                f"Number of executors {self.executors} cannot be converted to type int."
-            ) from exc
 
 
 def _wait_for(
@@ -384,7 +350,7 @@ def get_node_secret(
 
 
 def add_agent_node(
-    agent_meta: AgentMeta,
+    agent_meta: state.AgentMeta,
     credentials: Credentials,
     client: jenkinsapi.jenkins.Jenkins | None = None,
 ) -> None:

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -643,17 +643,3 @@ def get_agent_name(unit_name: str) -> str:
         The agent node name registered on Jenkins server.
     """
     return unit_name.replace("/", "-")
-
-
-def remove_agent_node(
-    agent_name: str, credentials: Credentials, client: jenkinsapi.jenkins.Jenkins | None = None
-) -> None:
-    """Remove registered agent from Jenkins server.
-
-    Args:
-        agent_name: The agent name to remove.
-        credentials: The credentials of a Jenkins user with access to the Jenkins API.
-        client: The API client used to communicate with the Jenkins server.
-    """
-    client = client if client is not None else _get_client(credentials)
-    client.delete_node(agent_name)

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -631,3 +631,29 @@ def safe_restart(
     ) as exc:
         logger.error("Failed to restart Jenkins, %s", exc)
         raise JenkinsError("Failed to restart Jenkins safely.") from exc
+
+
+def get_agent_name(unit_name: str) -> str:
+    """Infer agent name from unit name.
+
+    Args:
+        unit_name: The agent unit name.
+
+    Returns:
+        The agent node name registered on Jenkins server.
+    """
+    return unit_name.replace("/", "-")
+
+
+def remove_agent_node(
+    agent_name: str, credentials: Credentials, client: jenkinsapi.jenkins.Jenkins | None = None
+) -> None:
+    """Remove registered agent from Jenkins server.
+
+    Args:
+        agent_name: The agent name to remove.
+        credentials: The credentials of a Jenkins user with access to the Jenkins API.
+        client: The API client used to communicate with the Jenkins server.
+    """
+    client = client if client is not None else _get_client(credentials)
+    client.delete_node(agent_name)

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -90,7 +90,7 @@ class AgentMeta:
     Attributes:
         executors: Number of executors of the agent in string format.
         labels: Comma separated list of labels to be assigned to the agent.
-        slavehost: The host name of the agent.
+        name: The host name of the agent.
     """
 
     executors: str

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -95,7 +95,7 @@ class AgentMeta:
 
     executors: str
     labels: str
-    slavehost: str
+    name: str
 
     def validate(self) -> None:
         """Validate the agent metadata.
@@ -401,9 +401,9 @@ def add_agent_node(
     client = client if client is not None else _get_client(credentials)
     try:
         client.create_node(
-            name=agent_meta.slavehost,
+            name=agent_meta.name,
             num_executors=int(agent_meta.executors),
-            node_description=agent_meta.slavehost,
+            node_description=agent_meta.name,
             labels=agent_meta.labels,
         )
     except jenkinsapi.custom_exceptions.AlreadyExists:

--- a/src/state.py
+++ b/src/state.py
@@ -12,6 +12,9 @@ from timerange import InvalidTimeRangeError, Range
 
 logger = logging.getLogger(__name__)
 
+AGENT_RELATION = "agent"
+SLAVE_RELATION = "slave"
+
 
 class CharmStateBaseError(Exception):
     """Represents an error with charm state."""

--- a/src/state.py
+++ b/src/state.py
@@ -144,7 +144,6 @@ def _get_agent_meta_map_from_relation(
     Returns:
         A mapping of ops.Unit to AgentMetadata.
     """
-    print("RELATION RECEIVED, ", relation)
     if not relation:
         return None
     remote_units = filter(functools.partial(_is_remote_unit, current_app_name), relation.units)

--- a/src/state.py
+++ b/src/state.py
@@ -3,10 +3,12 @@
 
 """Jenkins States."""
 import dataclasses
+import functools
 import logging
 import typing
 
-from ops.charm import CharmBase
+import ops
+from pydantic import BaseModel, Field, ValidationError, validator
 
 from timerange import InvalidTimeRangeError, Range
 
@@ -36,20 +38,145 @@ class CharmConfigInvalidError(CharmStateBaseError):
         self.msg = msg
 
 
+class CharmRelationDataInvalidError(CharmStateBaseError):
+    """Represents an error with invalid data in relation data.
+
+    Attributes:
+        msg: Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the CharmRelationDataInvalidError exception.
+
+        Args:
+            msg: Explanation of the error.
+        """
+        self.msg = msg
+
+
+class AgentMeta(BaseModel):
+    """Metadata for registering Jenkins Agent.
+
+    Attributes:
+        executors: Number of executors of the agent in string format.
+        labels: Comma separated list of labels to be assigned to the agent.
+        name: The host name of the agent.
+    """
+
+    executors: str = Field(..., min_length=1)
+    labels: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+
+    @validator("executors")
+    # The decorated method does not need a self argument.
+    def numeric_executors(cls, value: str) -> int:  # noqa: N805 pylint: disable=no-self-argument
+        """Validate executors field can be converted to int.
+
+        Args:
+            value: The value of executors field.
+
+        Returns:
+            Coerced numerical value of executors.
+        """
+        return int(value)
+
+    @classmethod
+    def from_deprecated_agent_relation(
+        cls, relation_data: ops.RelationDataContent
+    ) -> typing.Optional["AgentMeta"]:
+        """Instantiate AgentMeta from charm relation databag.
+
+        Args:
+            relation_data: The unit relation databag.
+
+        Returns:
+            AgentMeta if complete values(executors, labels, slavehost) are set. None otherwise.
+        """
+        num_executors = relation_data.get("executors")
+        labels = relation_data.get("labels")
+        name = relation_data.get("slavehost")
+        if not num_executors or not labels or not name:
+            return None
+        return cls(executors=num_executors, labels=labels, name=name)
+
+    @classmethod
+    def from_agent_relation(
+        cls, relation_data: ops.RelationDataContent
+    ) -> typing.Optional["AgentMeta"]:
+        """Instantiate AgentMeta from charm relation databag.
+
+        Args:
+            relation_data: The unit relation databag.
+
+        Returns:
+            AgentMeta if complete values(executors, labels, slavehost) are set. None otherwise.
+        """
+        num_executors = relation_data.get("executors")
+        labels = relation_data.get("labels")
+        name = relation_data.get("name")
+        if not num_executors or not labels or not name:
+            return None
+        return cls(executors=num_executors, labels=labels, name=name)
+
+
+def _is_remote_unit(app_name: str, unit: ops.Unit) -> bool:
+    """Return whether the unit is a remote unit in a relation.
+
+    Args:
+        app_name: The current application name.
+        unit: The unit to check in a relation.
+
+    Returns:
+        True if is remote unit. False otherwise.
+    """
+    return app_name not in unit.name
+
+
+def _get_agent_meta_map_from_relation(
+    relation: typing.Optional[ops.Relation], current_app_name: str
+) -> typing.Optional[typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]]:
+    """Return a mapping of unit to AgentMetadata from agent or deprecated agent relation.
+
+    Args:
+        relation: The agent or deprecated agent relation.
+        current_app_name: Current application name, i.e. "jenkins-k8s-operator".
+
+    Returns:
+        A mapping of ops.Unit to AgentMetadata.
+    """
+    print("RELATION RECEIVED, ", relation)
+    if not relation:
+        return None
+    remote_units = filter(functools.partial(_is_remote_unit, current_app_name), relation.units)
+    if relation.name == DEPRECATED_AGENT_RELATION:
+        return {
+            unit: AgentMeta.from_deprecated_agent_relation(relation.data[unit])
+            for unit in remote_units
+        }
+    return {unit: AgentMeta.from_agent_relation(relation.data[unit]) for unit in remote_units}
+
+
 @dataclasses.dataclass(frozen=True)
 class State:
     """The Jenkins k8s operator charm state.
 
     Attributes:
-        jenkins_service_name: The Jenkins service name. Note that the container name is the same.
         update_time_range: Time range to allow Jenkins to update version.
+        agent_relation_meta: Metadata of all agents from units related through agent relation.
+        deprecated_agent_relation_meta: Metadata of all agents from units related through
+            deprecated agent relation.
+        jenkins_service_name: The Jenkins service name. Note that the container name is the same.
     """
 
     update_time_range: typing.Optional[Range]
+    agent_relation_meta: typing.Optional[typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]]
+    deprecated_agent_relation_meta: typing.Optional[
+        typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]
+    ]
     jenkins_service_name: str = "jenkins"
 
     @classmethod
-    def from_charm(cls, charm: CharmBase) -> "State":
+    def from_charm(cls, charm: ops.CharmBase) -> "State":
         """Initialize the state from charm.
 
         Args:
@@ -60,6 +187,7 @@ class State:
 
         Raises:
             CharmConfigInvalidError: if invalid state values were encountered.
+            CharmRelationDataInvalidError: if invalid relation data was received.
         """
         time_range_str = charm.config.get("update-time-range")
         if time_range_str:
@@ -73,4 +201,30 @@ class State:
         else:
             update_time_range = None
 
-        return cls(update_time_range=update_time_range)
+        try:
+            agent_relation_meta_map = _get_agent_meta_map_from_relation(
+                charm.model.get_relation(AGENT_RELATION), charm.app.name
+            )
+        except ValidationError as exc:
+            logger.error("Invalid agent relation data received from %s relation.", AGENT_RELATION)
+            raise CharmRelationDataInvalidError(
+                f"Invalid {AGENT_RELATION} relation data."
+            ) from exc
+
+        try:
+            deprecated_agent_meta_map = _get_agent_meta_map_from_relation(
+                charm.model.get_relation(DEPRECATED_AGENT_RELATION), charm.app.name
+            )
+        except ValidationError as exc:
+            logger.error(
+                "Invalid agent relation data received from %s relation.", DEPRECATED_AGENT_RELATION
+            )
+            raise CharmRelationDataInvalidError(
+                f"Invalid {DEPRECATED_AGENT_RELATION} relation data."
+            ) from exc
+
+        return cls(
+            update_time_range=update_time_range,
+            agent_relation_meta=agent_relation_meta_map,
+            deprecated_agent_relation_meta=deprecated_agent_meta_map,
+        )

--- a/src/state.py
+++ b/src/state.py
@@ -134,8 +134,8 @@ def _is_remote_unit(app_name: str, unit: ops.Unit) -> bool:
 
 def _get_agent_meta_map_from_relation(
     relation: typing.Optional[ops.Relation], current_app_name: str
-) -> typing.Optional[typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]]:
-    """Return a mapping of unit to AgentMetadata from agent or deprecated agent relation.
+) -> typing.Optional[typing.Mapping[str, typing.Optional[AgentMeta]]]:
+    """Return a mapping of unit name to AgentMetadata from agent or deprecated agent relation.
 
     Args:
         relation: The agent or deprecated agent relation.
@@ -149,10 +149,10 @@ def _get_agent_meta_map_from_relation(
     remote_units = filter(functools.partial(_is_remote_unit, current_app_name), relation.units)
     if relation.name == DEPRECATED_AGENT_RELATION:
         return {
-            unit: AgentMeta.from_deprecated_agent_relation(relation.data[unit])
+            unit.name: AgentMeta.from_deprecated_agent_relation(relation.data[unit])
             for unit in remote_units
         }
-    return {unit: AgentMeta.from_agent_relation(relation.data[unit]) for unit in remote_units}
+    return {unit.name: AgentMeta.from_agent_relation(relation.data[unit]) for unit in remote_units}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -168,9 +168,9 @@ class State:
     """
 
     update_time_range: typing.Optional[Range]
-    agent_relation_meta: typing.Optional[typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]]
+    agent_relation_meta: typing.Optional[typing.Mapping[str, typing.Optional[AgentMeta]]]
     deprecated_agent_relation_meta: typing.Optional[
-        typing.Mapping[ops.Unit, typing.Optional[AgentMeta]]
+        typing.Mapping[str, typing.Optional[AgentMeta]]
     ]
     jenkins_service_name: str = "jenkins"
 

--- a/src/state.py
+++ b/src/state.py
@@ -13,7 +13,7 @@ from timerange import InvalidTimeRangeError, Range
 logger = logging.getLogger(__name__)
 
 AGENT_RELATION = "agent"
-SLAVE_RELATION = "slave"
+DEPRECATED_AGENT_RELATION = "agent-deprecated"
 
 
 class CharmStateBaseError(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,5 @@ def pytest_addoption(parser: pytest.Parser):
     """
     # The Jenkins image name:tag.
     parser.addoption("--jenkins-image", action="store", default="")
+    # The number of jenkins agents to deploy and relate.
+    parser.addoption("--num-units", action="store", default="1")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,8 +3,10 @@
 
 """Fixtures for Jenkins-k8s-operator charm integration tests."""
 
+import random
 import re
 import secrets
+import string
 import textwrap
 import typing
 
@@ -84,13 +86,15 @@ async def web_address_fixture(unit_ip: str):
 @pytest_asyncio.fixture(scope="function", name="jenkins_k8s_agent")
 async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Application, None]:
     """The Jenkins k8s agent."""
+    # secrets random hex cannot be used because it has chances to generate numeric only suffix
+    # which will return "<application-name> is not a valid application tag"
+    app_suffix = "".join(random.choices(string.ascii_lowercase, k=4))
     agent_app: Application = await model.deploy(
         "jenkins-agent-k8s",
         config={"jenkins_agent_labels": "k8s"},
         channel="edge",
         num_units=3,
-        application_name=f"jenkinsagentk8s-{secrets.token_urlsafe(2)}",  # the name should pass the
-        # regex (?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*) with application- prefix.
+        application_name=f"jenkins-agentk8s-{app_suffix}",
     )
     await model.wait_for_idle(apps=[agent_app.name], status="blocked")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,7 @@ async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Appli
         config={"jenkins_agent_labels": "k8s"},
         channel="edge",
         num_units=3,
-        application_name=f"jenkins-agentk8s-{secrets.token_hex(2)}",
+        application_name=f"jenkins-agentk8s-{secrets.token_urlsafe(2)}",
     )
     await model.wait_for_idle(apps=[agent_app.name], status="blocked")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -82,7 +82,7 @@ async def web_address_fixture(unit_ip: str):
 
 
 @pytest_asyncio.fixture(scope="function", name="jenkins_k8s_agent")
-async def jenkins_k8s_agent_fixture(model: Model) -> Application:
+async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Application, None]:
     """The Jenkins k8s agent."""
     agent_app: Application = await model.deploy(
         "jenkins-agent-k8s",
@@ -172,7 +172,9 @@ async def machine_model_fixture(
 
 
 @pytest_asyncio.fixture(scope="function", name="jenkins_machine_agent")
-async def jenkins_machine_agent_fixture(machine_model: Model) -> Application:
+async def jenkins_machine_agent_fixture(
+    machine_model: Model,
+) -> typing.AsyncGenerator[Application, None]:
     """The jenkins machine agent."""
     # 2023-06-02 use the edge version of jenkins agent until the changes have been promoted to
     # stable.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,7 +46,7 @@ def jenkins_image_fixture(request: FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="module", name="num_units")
-def num_units_fixture(request: FixtureRequest) -> str:
+def num_units_fixture(request: FixtureRequest) -> int:
     """The OCI image for Jenkins charm."""
     return int(request.config.getoption("--num-units"))
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,12 @@ def jenkins_image_fixture(request: FixtureRequest) -> str:
     return jenkins_image
 
 
+@pytest.fixture(scope="module", name="num_units")
+def num_units_fixture(request: FixtureRequest) -> str:
+    """The OCI image for Jenkins charm."""
+    return int(request.config.getoption("--num-units"))
+
+
 @pytest_asyncio.fixture(scope="module", name="application")
 async def application_fixture(
     ops_test: OpsTest, model: Model, jenkins_image: str
@@ -84,7 +90,9 @@ async def web_address_fixture(unit_ip: str):
 
 
 @pytest_asyncio.fixture(scope="function", name="jenkins_k8s_agent")
-async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Application, None]:
+async def jenkins_k8s_agent_fixture(
+    model: Model, num_units: int
+) -> typing.AsyncGenerator[Application, None]:
     """The Jenkins k8s agent."""
     # secrets random hex cannot be used because it has chances to generate numeric only suffix
     # which will return "<application-name> is not a valid application tag"
@@ -93,7 +101,7 @@ async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Appli
         "jenkins-agent-k8s",
         config={"jenkins_agent_labels": "k8s"},
         channel="edge",
-        num_units=3,
+        num_units=num_units,
         application_name=f"jenkins-agentk8s-{app_suffix}",
     )
     await model.wait_for_idle(apps=[agent_app.name], status="blocked")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,7 +88,7 @@ async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Appli
     """The Jenkins k8s agent."""
     # secrets random hex cannot be used because it has chances to generate numeric only suffix
     # which will return "<application-name> is not a valid application tag"
-    app_suffix = "".join(random.choices(string.ascii_lowercase, k=4))
+    app_suffix = "".join(random.choices(string.ascii_lowercase, k=4))  # nosec
     agent_app: Application = await model.deploy(
         "jenkins-agent-k8s",
         config={"jenkins_agent_labels": "k8s"},

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,8 @@ async def jenkins_k8s_agent_fixture(model: Model) -> typing.AsyncGenerator[Appli
         config={"jenkins_agent_labels": "k8s"},
         channel="edge",
         num_units=3,
-        application_name=f"jenkins-agentk8s-{secrets.token_urlsafe(2)}",
+        application_name=f"jenkinsagentk8s-{secrets.token_urlsafe(2)}",  # the name should pass the
+        # regex (?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*) with application- prefix.
     )
     await model.wait_for_idle(apps=[agent_app.name], status="blocked")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -177,9 +177,7 @@ async def machine_model_fixture(
 
 
 @pytest_asyncio.fixture(scope="function", name="jenkins_machine_agent")
-async def jenkins_machine_agent_fixture(
-    machine_model: Model,
-) -> typing.AsyncGenerator[Application, None]:
+async def jenkins_machine_agent_fixture(machine_model: Model) -> Application:
     """The jenkins machine agent."""
     # 2023-06-02 use the edge version of jenkins agent until the changes have been promoted to
     # stable.
@@ -188,9 +186,7 @@ async def jenkins_machine_agent_fixture(
     )
     await machine_model.wait_for_idle(apps=[app.name], status="blocked", timeout=1200)
 
-    yield app
-
-    await machine_model.remove_application(app.name, force=True)
+    return app
 
 
 @pytest.fixture(scope="module", name="jenkins_version")

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -72,7 +72,7 @@ async def test_jenkins_machine_slave_relation(
     await machine_model.create_offer(f"{jenkins_machine_agent.name}:slave")
     model: Model = application.model
     await model.relate(
-        f"{application.name}:agent",
+        f"{application.name}:slave",
         f"localhost:admin/{machine_model.name}.{jenkins_machine_agent.name}",
     )
     await model.wait_for_idle(status="active", timeout=1200)

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -52,7 +52,7 @@ async def test_jenkins_deprecated_agent_relation(
         (jenkins_k8s_agent.name in key for key in nodes.keys())
     ), "Jenkins k8s agent node not registered."
 
-    job = jenkins_client.create_job("test", gen_jenkins_test_job_xml("k8s"))
+    job = jenkins_client.create_job(jenkins_k8s_agent.name, gen_jenkins_test_job_xml("k8s"))
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()
@@ -84,7 +84,9 @@ async def test_jenkins_machine_deprecated_agent_relation(
         ("jenkins-agent-0" in key for key in nodes.keys())
     ), "Jenkins agent node not registered."
 
-    job = jenkins_client.create_job("test", gen_jenkins_test_job_xml("machine"))
+    job = jenkins_client.create_job(
+        jenkins_machine_agent.name, gen_jenkins_test_job_xml("machine")
+    )
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()
@@ -111,7 +113,7 @@ async def test_jenkins_k8s_agent_relation(
         (jenkins_k8s_agent.name in key for key in nodes.keys())
     ), "Jenkins k8s agent node not registered."
 
-    job = jenkins_client.create_job("test", gen_jenkins_test_job_xml("k8s"))
+    job = jenkins_client.create_job(jenkins_k8s_agent.name, gen_jenkins_test_job_xml("k8s"))
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,7 @@ from ops.model import Container
 from ops.pebble import ExecError
 from ops.testing import Harness
 
+import state
 from charm import JenkinsK8sOperatorCharm
 from jenkins import PASSWORD_FILE_PATH, PLUGINS_PATH, REQUIRED_PLUGINS, Credentials
 
@@ -227,14 +228,32 @@ def raise_exception_fixture():
     return raise_exception
 
 
-@pytest.fixture(scope="function", name="agent_relation_data")
-def agent_relation_data_fixture():
+@pytest.fixture(scope="function", name="get_relation_data")
+def get_relation_data_fixture():
     """The agent relation data required to register agent."""
-    return {
-        "executors": "2",
-        "labels": "x84_64",
-        "slavehost": "http://sample-address:8080",
-    }
+
+    def get_relation_data(relation: str):
+        """Return a valid relation data matching the relation interface.
+
+        Args:
+            relation: The relation name.
+
+        Returns:
+            A valid test relation data.
+        """
+        if relation == state.SLAVE_RELATION:
+            return {
+                "executors": "2",
+                "labels": "x84_64",
+                "slavehost": "jenkins-agent-0",
+            }
+        return {
+            "executors": "2",
+            "labels": "x84_64",
+            "name": "jenkins-agent-0",
+        }
+
+    return get_relation_data
 
 
 @pytest.fixture(scope="function", name="current_version")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -241,7 +241,7 @@ def get_relation_data_fixture():
         Returns:
             A valid test relation data.
         """
-        if relation == state.SLAVE_RELATION:
+        if relation == state.DEPRECATED_AGENT_RELATION:
             return {
                 "executors": "2",
                 "labels": "x84_64",

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -35,7 +35,7 @@ def test__on_agent_relation_joined_no_container(harness_container: HarnessWithCo
     jenkins_charm = cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     mock_event = MagicMock(spec=PebbleReadyEvent)
 
-    jenkins_charm.agent_observer._on_agent_relation_joined(mock_event)
+    jenkins_charm.agent_observer._on_slave_relation_joined(mock_event)
 
     assert mock_event.defer.to_be_called_once()
     assert jenkins_charm.unit.status.name == MAINTENANCE_STATUS_NAME

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -27,7 +27,7 @@ from .types_ import HarnessWithContainer
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_joined_no_container(
@@ -48,7 +48,7 @@ def test__on_agent_relation_joined_no_container(
     if relation == state.AGENT_RELATION:
         jenkins_charm.agent_observer._on_agent_relation_joined(mock_event)
     else:
-        jenkins_charm.agent_observer._on_slave_relation_joined(mock_event)
+        jenkins_charm.agent_observer._on_deprecated_agent_relation_joined(mock_event)
 
     assert mock_event.defer.to_be_called_once()
     assert jenkins_charm.unit.status.name == MAINTENANCE_STATUS_NAME
@@ -58,7 +58,7 @@ def test__on_agent_relation_joined_no_container(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="slave relation"),
     ],
 )
 def test__on_agent_relation_joined_relation_data_not_set(
@@ -89,8 +89,8 @@ def test__on_agent_relation_joined_relation_data_not_set(
                 "labels": "x84_64",
                 "slavehost": "http://sample-address:8080",
             },
-            state.SLAVE_RELATION,
-            id="non-numeric executor(slave)",
+            state.DEPRECATED_AGENT_RELATION,
+            id="non-numeric executor(deprecated agent)",
         ),
         pytest.param(
             {
@@ -98,8 +98,8 @@ def test__on_agent_relation_joined_relation_data_not_set(
                 "labels": "x84_64",
                 "slavehost": "http://sample-address:8080",
             },
-            state.SLAVE_RELATION,
-            id="Non int convertible(slave)",
+            state.DEPRECATED_AGENT_RELATION,
+            id="Non int convertible(deprecated agent)",
         ),
         pytest.param(
             {
@@ -154,7 +154,7 @@ def test__on_agent_relation_joined_relation_data_not_valid(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_joined_client_error(
@@ -204,7 +204,7 @@ def test__on_agent_relation_joined_client_error(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_joined(
@@ -255,7 +255,7 @@ def test__on_agent_relation_joined(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_departed_no_container(
@@ -289,7 +289,7 @@ def test__on_agent_relation_departed_no_container(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_departed_remove_agent_node_error(
@@ -332,7 +332,7 @@ def test__on_agent_relation_departed_remove_agent_node_error(
     "relation",
     [
         pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
+        pytest.param(state.DEPRECATED_AGENT_RELATION, id="deprecated agent relation"),
     ],
 )
 def test__on_agent_relation_departed(

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -16,6 +16,7 @@ from ops.charm import PebbleReadyEvent
 
 import charm
 import jenkins
+import state
 from charm import JenkinsK8sOperatorCharm
 
 from .helpers import ACTIVE_STATUS_NAME, BLOCKED_STATUS_NAME, MAINTENANCE_STATUS_NAME
@@ -48,11 +49,13 @@ def test__on_agent_relation_joined_relation_data_not_set(harness_container: Harn
     assert: the event is deferred.
     """
     harness_container.harness.begin()
-    relation_id = harness_container.harness.add_relation("agent", "jenkins-agent")
+    relation_id = harness_container.harness.add_relation(state.SLAVE_RELATION, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")
 
-    relation = harness_container.harness.charm.model.get_relation("agent", relation_id)
-    harness_container.harness.charm.on["agent"].relation_joined.emit(relation)
+    relation = harness_container.harness.charm.model.get_relation(
+        state.SLAVE_RELATION, relation_id
+    )
+    harness_container.harness.charm.on[state.SLAVE_RELATION].relation_joined.emit(relation)
 
     jenkins_charm = cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     assert jenkins_charm.unit.status.name == MAINTENANCE_STATUS_NAME
@@ -88,7 +91,7 @@ def test__on_agent_relation_joined_relation_data_not_valid(
     assert: the unit falls to BlockedStatus.
     """
     harness_container.harness.begin()
-    relation_id = harness_container.harness.add_relation("agent", "jenkins-agent")
+    relation_id = harness_container.harness.add_relation(state.SLAVE_RELATION, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")
     harness_container.harness.update_relation_data(
         relation_id,
@@ -96,8 +99,10 @@ def test__on_agent_relation_joined_relation_data_not_valid(
         relation_data,
     )
 
-    relation = harness_container.harness.charm.model.get_relation("agent", relation_id)
-    harness_container.harness.charm.on["agent"].relation_joined.emit(
+    relation = harness_container.harness.charm.model.get_relation(
+        state.SLAVE_RELATION, relation_id
+    )
+    harness_container.harness.charm.on[state.SLAVE_RELATION].relation_joined.emit(
         relation,
         app=harness_container.harness.model.get_app("jenkins-agent"),
         unit=harness_container.harness.model.get_unit("jenkins-agent/0"),
@@ -130,7 +135,7 @@ def test__on_agent_relation_joined_client_error(
         lambda *_args, **_kwargs: raise_exception(exception=jenkins.JenkinsError()),
     )
     harness_container.harness.begin()
-    relation_id = harness_container.harness.add_relation("agent", "jenkins-agent")
+    relation_id = harness_container.harness.add_relation(state.SLAVE_RELATION, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")
     harness_container.harness.update_relation_data(
         relation_id,
@@ -138,8 +143,10 @@ def test__on_agent_relation_joined_client_error(
         agent_relation_data,
     )
 
-    relation = harness_container.harness.charm.model.get_relation("agent", relation_id)
-    harness_container.harness.charm.on["agent"].relation_joined.emit(
+    relation = harness_container.harness.charm.model.get_relation(
+        state.SLAVE_RELATION, relation_id
+    )
+    harness_container.harness.charm.on[state.SLAVE_RELATION].relation_joined.emit(
         relation,
         app=harness_container.harness.model.get_app("jenkins-agent"),
         unit=harness_container.harness.model.get_unit("jenkins-agent/0"),
@@ -174,7 +181,7 @@ def test__on_agent_relation_joined(
     # The charm code `binding.network.bind_address` for getting unit ip address will fail without
     # the add_network call.
     harness_container.harness.add_network("10.0.0.10")
-    relation_id = harness_container.harness.add_relation("agent", "jenkins-agent")
+    relation_id = harness_container.harness.add_relation(state.SLAVE_RELATION, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")
     harness_container.harness.update_relation_data(
         relation_id,
@@ -182,8 +189,10 @@ def test__on_agent_relation_joined(
         agent_relation_data,
     )
 
-    relation = harness_container.harness.charm.model.get_relation("agent", relation_id)
-    harness_container.harness.charm.on["agent"].relation_joined.emit(
+    relation = harness_container.harness.charm.model.get_relation(
+        state.SLAVE_RELATION, relation_id
+    )
+    harness_container.harness.charm.on[state.SLAVE_RELATION].relation_joined.emit(
         relation,
         app=harness_container.harness.model.get_app("jenkins-agent"),
         unit=harness_container.harness.model.get_unit("jenkins-agent/0"),

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -397,11 +397,11 @@ def test_add_agent_node(admin_credentials: jenkins.Credentials):
     "invalid_meta,expected_err_message",
     [
         pytest.param(
-            jenkins.AgentMeta(executors="", labels="abc", slavehost="http://sample-host:8080"),
+            jenkins.AgentMeta(executors="", labels="abc", name="http://sample-host:8080"),
             "Fields ['executors'] cannot be empty.",
         ),
         pytest.param(
-            jenkins.AgentMeta(executors="abc", labels="abc", slavehost="http://sample-host:8080"),
+            jenkins.AgentMeta(executors="abc", labels="abc", name="http://sample-host:8080"),
             "Number of executors abc cannot be converted to type int.",
         ),
     ],

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -393,6 +393,34 @@ def test_add_agent_node(admin_credentials: jenkins.Credentials):
     )
 
 
+def test_remove_agent_node_fail(admin_credentials: jenkins.Credentials):
+    """
+    arrange: given a mocked jenkins client.
+    act: when add_agent is called.
+    assert: no exception is raised.
+    """
+    mock_jenkins_client = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins)
+    mock_jenkins_client.delete_node.side_effect = jenkinsapi.custom_exceptions.JenkinsAPIException
+
+    with pytest.raises(jenkins.JenkinsError):
+        jenkins.remove_agent_node("jekins-agent-0", admin_credentials, mock_jenkins_client)
+
+
+def test_remove_agent_node(admin_credentials: jenkins.Credentials):
+    """
+    arrange: given a mocked jenkins client.
+    act: when add_agent is called.
+    assert: no exception is raised.
+    """
+    mock_delete = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins.delete_node)
+    mock_jenkins_client = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins)
+    mock_jenkins_client.delete_node = mock_delete
+
+    jenkins.remove_agent_node("jekins-agent-0", admin_credentials, mock_jenkins_client)
+
+    mock_delete.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "invalid_meta,expected_err_message",
     [

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -270,7 +270,7 @@ def test_bootstrap_fail(
     )
 
     with pytest.raises(jenkins.JenkinsBootstrapError):
-        jenkins.bootstrap(connectable_container=harness_container.container)
+        jenkins.bootstrap(container=harness_container.container)
 
 
 def test_bootstrap(
@@ -285,7 +285,7 @@ def test_bootstrap(
     """
     monkeypatch.setattr(jenkins, "get_version", lambda: jenkins_version)
 
-    jenkins.bootstrap(connectable_container=harness_container.container)
+    jenkins.bootstrap(container=harness_container.container)
 
     assert harness_container.container.pull(
         jenkins.LAST_EXEC_VERSION_PATH, encoding="utf-8"
@@ -317,7 +317,7 @@ def test_get_client(admin_credentials: jenkins.Credentials):
         )
 
 
-def test_get_node_secret_api_error(admin_credentials: jenkins.Credentials):
+def test_get_node_secret_api_error(container: Container):
     """
     arrange: given a mocked Jenkins client that raises an error.
     act: when a groovy script is executed through the client.
@@ -329,10 +329,10 @@ def test_get_node_secret_api_error(admin_credentials: jenkins.Credentials):
     )
 
     with pytest.raises(jenkins.JenkinsError):
-        jenkins.get_node_secret("jenkins-agent", admin_credentials, mock_jenkins_client)
+        jenkins.get_node_secret("jenkins-agent", container, mock_jenkins_client)
 
 
-def test_get_node_secret(admin_credentials: jenkins.Credentials):
+def test_get_node_secret(container: Container):
     """
     arrange: given a mocked Jenkins client.
     act: when a groovy script getting a node secret is executed.
@@ -342,12 +342,12 @@ def test_get_node_secret(admin_credentials: jenkins.Credentials):
     mock_jenkins_client = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins)
     mock_jenkins_client.run_groovy_script.return_value = secret
 
-    node_secret = jenkins.get_node_secret("jenkins-agent", admin_credentials, mock_jenkins_client)
+    node_secret = jenkins.get_node_secret("jenkins-agent", container, mock_jenkins_client)
 
     assert secret == node_secret, "Secret value mismatch."
 
 
-def test_add_agent_node_fail(admin_credentials: jenkins.Credentials):
+def test_add_agent_node_fail(container: Container):
     """
     arrange: given a mocked jenkins client that raises an API exception.
     act: when add_agent is called
@@ -359,12 +359,12 @@ def test_add_agent_node_fail(admin_credentials: jenkins.Credentials):
     with pytest.raises(jenkins.JenkinsError):
         jenkins.add_agent_node(
             state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
-            admin_credentials,
+            container,
             mock_jenkins_client,
         )
 
 
-def test_add_agent_node_already_exists(admin_credentials: jenkins.Credentials):
+def test_add_agent_node_already_exists(container: Container):
     """
     arrange: given a mocked jenkins client that raises an Already exists exception.
     act: when add_agent is called.
@@ -375,12 +375,12 @@ def test_add_agent_node_already_exists(admin_credentials: jenkins.Credentials):
 
     jenkins.add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
-        admin_credentials,
+        container,
         mock_jenkins_client,
     )
 
 
-def test_add_agent_node(admin_credentials: jenkins.Credentials):
+def test_add_agent_node(container: Container):
     """
     arrange: given a mocked jenkins client.
     act: when add_agent is called.
@@ -393,7 +393,7 @@ def test_add_agent_node(admin_credentials: jenkins.Credentials):
 
     jenkins.add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
-        admin_credentials,
+        container,
         mock_jenkins_client,
     )
 
@@ -622,10 +622,10 @@ def test_download_stable_war_failure(monkeypatch: pytest.MonkeyPatch, current_ve
     assert: JenkinsNetworkError is raised.
     """
     monkeypatch.setattr(requests, "get", ConnectionExceptionPatch)
-    connectable_container = unittest.mock.MagicMock(spec=Container)
+    container = unittest.mock.MagicMock(spec=Container)
 
     with pytest.raises(jenkins.JenkinsNetworkError):
-        jenkins.download_stable_war(connectable_container, current_version)
+        jenkins.download_stable_war(container, current_version)
 
 
 def test_download_stable_war(monkeypatch: pytest.MonkeyPatch, current_version: str):
@@ -637,11 +637,11 @@ def test_download_stable_war(monkeypatch: pytest.MonkeyPatch, current_version: s
     mock_download_response = unittest.mock.MagicMock(spec=requests.Response)
     mock_download_response.content = b"mock war content"
     monkeypatch.setattr(requests, "get", lambda *_, **__: mock_download_response)
-    connectable_container = unittest.mock.MagicMock(spec=Container)
+    container = unittest.mock.MagicMock(spec=Container)
 
-    jenkins.download_stable_war(connectable_container, current_version)
+    jenkins.download_stable_war(container, current_version)
 
-    connectable_container.push.assert_called_once_with(
+    container.push.assert_called_once_with(
         jenkins.EXECUTABLES_PATH / "jenkins.war",
         mock_download_response.content,
         encoding="utf-8",

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -42,3 +42,38 @@ def test_no_time_range_config(time_range: str, harness: Harness):
     assert (
         typing.cast(charm.JenkinsK8sOperatorCharm, harness.charm).state.update_time_range is None
     ), "Update time range should not be instantiated."
+
+
+class TestAgentMeta(typing.TypedDict):
+    """Metadata wrapper for testing.
+
+    Attrs:
+        executors: Number of executors.
+        labels: Label to be given to agent.
+        name: Name of the agent.
+    """
+
+    executors: str
+    labels: str
+    name: str
+
+
+@pytest.mark.parametrize(
+    "invalid_meta",
+    [
+        pytest.param(
+            TestAgentMeta(executors="", labels="abc", name="http://sample-host:8080"),
+        ),
+        pytest.param(
+            TestAgentMeta(executors="abc", labels="abc", name="http://sample-host:8080"),
+        ),
+    ],
+)
+def test_agent_meta__validate(invalid_meta: TestAgentMeta):
+    """
+    arrange: given an invalid agent metadata tuple.
+    act: when validate is called.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(state.ValidationError):
+        state.AgentMeta(**invalid_meta)


### PR DESCRIPTION
This PR introduces the new agent_v0_interface under the `agent` relation.

It further addresses:
- code styling changes to import directly from the `ops` pacakge.
- removing `self._jenkins_container` replacing it as single use container get
- 1:1 callback methods for each event handler
- remove registered agent on relation broken.