### PR TITLE
fix: >1 app per relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,10 +33,16 @@ tags:
 containers:
   jenkins:
     resource: jenkins-image
+  telemetry:
+    resource: opentelemetry-collector
 resources:
   jenkins-image:
     type: oci-image
     description: OCI image for Jenkins
+  opentelemetry-collector:
+    type: oci-image
+    description: OCI image for opentelemetry-collector
+    upstream-source: otel/opentelemetry-collector:0.84.0
 requires:
   agent-deprecated:
     interface: jenkins-slave
@@ -44,3 +50,4 @@ requires:
   agent:
     interface: jenkins_agent_v0
     optional: true
+    limit: 2

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,16 +33,10 @@ tags:
 containers:
   jenkins:
     resource: jenkins-image
-  telemetry:
-    resource: opentelemetry-collector
 resources:
   jenkins-image:
     type: oci-image
     description: OCI image for Jenkins
-  opentelemetry-collector:
-    type: oci-image
-    description: OCI image for opentelemetry-collector
-    upstream-source: otel/opentelemetry-collector:0.84.0
 requires:
   agent-deprecated:
     interface: jenkins-slave

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -368,7 +368,7 @@ Infer agent name from unit name.
 
 ---
 
-<a href="../src/jenkins.py#L885"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L878"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_unlisted_plugins`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -190,7 +190,7 @@ Configuration for accessing Jenkins through proxy.
 
 ---
 
-<a href="../src/state.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -227,7 +227,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -188,6 +188,22 @@ async def app_k8s_agent_related_fixture(
     yield application
 
 
+@pytest_asyncio.fixture(scope="function", name="extra_jenkins_k8s_agents")
+async def extra_jenkins_k8s_agents_fixture(
+    model: Model,
+) -> typing.AsyncGenerator[Application, None]:
+    """The Jenkins k8s agent."""
+    agent_app: Application = await model.deploy(
+        "jenkins-agent-k8s",
+        config={"jenkins_agent_labels": "k8s-extra"},
+        channel="latest/edge",
+        application_name="jenkins-agentk8s-extra",
+    )
+    await model.wait_for_idle(apps=[agent_app.name], status="blocked")
+
+    yield agent_app
+
+
 @pytest_asyncio.fixture(scope="function", name="app_k8s_deprecated_agent_related")
 async def app_k8s_deprecated_agent_related_fixture(
     jenkins_k8s_agents: Application,


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Allow more than one agent application to connect to the `agent` relation endpoint.

### Rationale

This would allow k8s and machine agents to share a same Jenkins server.

### Juju Events Changes

None.

### Module Changes

`state.py`'s method of getting relation are changed from a singular relation fetching method `relations.get(RELATION_NAME)` to `relations[RELATION_NAME]`.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
