### PR TITLE
fix: use function level client fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -121,7 +121,7 @@ def web_address_fixture(unit_ip: str):
     return f"http://{unit_ip}:8080"
 
 
-@pytest_asyncio.fixture(scope="module", name="jenkins_client")
+@pytest_asyncio.fixture(scope="function", name="jenkins_client")
 async def jenkins_client_fixture(
     application: Application,
     web_address: str,
@@ -139,7 +139,7 @@ async def jenkins_client_fixture(
     )
 
 
-@pytest.fixture(scope="module", name="unit_web_client")
+@pytest.fixture(scope="function", name="unit_web_client")
 def unit_web_client_fixture(
     unit: Unit, web_address: str, jenkins_client: jenkinsapi.jenkins.Jenkins
 ):


### PR DESCRIPTION
Applicable spec: NA

### Overview

Use function level client fixtures to avoid Unauthorized 401 error in integration tests.

### Rationale

To reduce flakiness of the integration tests.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
