### PR TITLE
chore: update jenkins lts version

### DIFF
--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -40,8 +40,8 @@ parts:
       - default-jre-headless
       - git
     build-environment:
-      - JENKINS_VERSION: 2.387
-      - JENKINS_PLUGIN_MANAGER_VERSION: 2.12.11
+      - JENKINS_VERSION: 2.414.1
+      - JENKINS_PLUGIN_MANAGER_VERSION: 2.12.13
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/{srv/jenkins/,etc/default/jenkins/}
       # Use jenkins war rather than apt install for easier Jenkins version control.

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -352,7 +352,7 @@ def _install_plugins(
         "java",
         *proxy_args,
         "-jar",
-        "jenkins-plugin-manager-2.12.11.jar",
+        "jenkins-plugin-manager-2.12.13.jar",
         "-w",
         "jenkins.war",
         "-d",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -42,7 +42,7 @@ async def install_plugins(
         unit.name,
         "java",
         "-jar",
-        f"{jenkins.EXECUTABLES_PATH / 'jenkins-plugin-manager-2.12.11.jar'}",
+        f"{jenkins.EXECUTABLES_PATH / 'jenkins-plugin-manager-2.12.13.jar'}",
         "-w",
         f"{jenkins.EXECUTABLES_PATH / 'jenkins.war'}",
         "-d",

--- a/tests/integration/test_k8s_agent.py
+++ b/tests/integration/test_k8s_agent.py
@@ -33,7 +33,7 @@ async def test_jenkins_wizard_bypass(web_address: str):
     # This should not appear since when Jenkins setup is complete, the wizard should have been
     # bypassed.
     assert "Unlock Jenkins" not in str(response.content), "Jenkins setup wizard not bypassed."
-    assert "Welcome to Jenkins!" in str(response.content)
+    assert "Sign in to Jenkins" in str(response.content)
 
 
 async def test_jenkins_k8s_agent_relation(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -198,7 +198,7 @@ def container_fixture(
             case _ if [
                 "java",
                 "-jar",
-                "jenkins-plugin-manager-2.12.11.jar",
+                "jenkins-plugin-manager-2.12.13.jar",
                 "-w",
                 "jenkins.war",
                 "-d",
@@ -219,7 +219,7 @@ def container_fixture(
                 f"-Dhttps.proxyPassword={proxy_config.https_proxy.password}",
                 f'-Dhttp.nonProxyHosts="{no_proxy_hosts}"',
                 "-jar",
-                "jenkins-plugin-manager-2.12.11.jar",
+                "jenkins-plugin-manager-2.12.13.jar",
                 "-w",
                 "jenkins.war",
                 "-d",


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Bump Jenkins LTS version to latest release & Jenkins plugin manager to latest patch.

### Rationale

To support latest version of Jenkins.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
