### PR TITLE
fix: filter unit running job

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,4 +15,4 @@ jobs:
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
       modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
-
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,4 +15,4 @@ jobs:
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
       modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
-      tmate-debug: true
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -172,6 +172,8 @@ async def jenkins_k8s_agents_fixture(
 
     yield agent_app
 
+    await model.remove_application(agent_app.name, block_until_done=True, force=True)
+
 
 @pytest_asyncio.fixture(scope="function", name="app_k8s_agent_related")
 async def app_k8s_agent_related_fixture(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -255,3 +255,21 @@ async def wait_for(
         if result := func():
             return result
     raise TimeoutError()
+
+
+def get_job_invoked_unit(job: jenkins.jenkinsapi.job.Job, units: typing.List[Unit]) -> Unit | None:
+    """Get the jenkins unit that has run the latest job.
+
+    Args:
+        job: The jenkins job that has been run.
+        units: Jenkins agent units.
+
+    Returns:
+        The agent unit that run the job if found.
+    """
+    invoked_agent = job.get_last_build().get_slave()
+    unit: Unit
+    for unit in units:
+        if unit.name.replace("/", "-") == invoked_agent:
+            return unit
+    return None


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Filter the unit that has run the postbuildscript job so that the tests are less flaky.

### Rationale

To make the tests less flaky.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
