### PR TITLE
test: blueocean plugin

### DIFF
--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -219,3 +219,20 @@ async def test_postbuildscript_plugin(
     )
     assert ret == 0, f"Failed to scp test output file, {stderr}"
     assert stdout == test_output
+
+
+async def test_blueocean_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+    """
+    arrange: given a jenkins charm with blueocean plugin installed.
+    act: when blueocean frontend url is accessed.
+    assert: 200 response is returned.
+    """
+    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("blueocean",))
+
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/blue/organizations/jenkins/"
+    )
+
+    assert (
+        res.status_code == 200
+    ), f"Failed to access Blueocean frontend, {str(res.content, encoding='utf-8')}"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds a test for blueocean plugin frontend load.

### Rationale

To add support for blueocean plugin.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
