### PR TITLE
test: ssh_agent plugin

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -69,7 +69,7 @@ async def install_plugins(
     )
 
 
-def _get_test_job_xml(node_label: str):
+def gen_test_job_xml(node_label: str):
     """Generate a job xml with target node label.
 
     Args:
@@ -121,7 +121,7 @@ def assert_job_success(
         (agent_name in key for key in nodes.keys())
     ), f"Jenkins {agent_name} node not registered."
 
-    job = client.create_job(agent_name, _get_test_job_xml(test_target_label))
+    job = client.create_job(agent_name, gen_test_job_xml(test_target_label))
     queue_item = job.invoke()
     queue_item.block_until_complete()
     build: jenkinsapi.build.Build = queue_item.get_build()

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -12,7 +12,7 @@ from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
 from .constants import ALLOWED_PLUGINS, INSTALLED_PLUGINS, REMOVED_PLUGINS
-from .helpers import gen_git_test_job_xml, get_job_invoked_unit, install_plugins
+from .helpers import gen_git_test_job_xml, gen_test_job_xml, get_job_invoked_unit, install_plugins
 from .types_ import TestLDAPSettings, UnitWebClient
 
 
@@ -219,3 +219,20 @@ async def test_postbuildscript_plugin(
     )
     assert ret == 0, f"Failed to scp test output file, {stderr}"
     assert stdout == test_output
+
+
+async def test_ssh_agent_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+    """
+    arrange: given jenkins charm with ssh_agent plugin installed.
+    act: when a job is being configured.
+    assert: ssh-agent configuration is visible.
+    """
+    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("ssh-agent",))
+    unit_web_client.client.create_job("ssh_agent_test", gen_test_job_xml("k8s"))
+
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/job/ssh_agent_test/configure"
+    )
+
+    config_page = str(res.content, "utf-8")
+    assert "SSH Agent" in config_page, f"SSH agent configuration not found. {config_page}"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds integration test to ssh_agent plugin. Only a UI test is done rather than a functional test since installation of ssh-agent on the jenkins agent and testing for it is out of the scope of this repository.

### Rationale

To test for the commonly used plugin: ssh_agent.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
