### PR TITLE
feat: limit num units deployment to 1

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,7 +12,7 @@ Charm Jenkins.
 ## <kbd>class</kbd> `JenkinsK8sOperatorCharm`
 Charm Jenkins. 
 
-<a href="../src/charm.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L35"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -29,7 +29,7 @@ Metadata for registering Jenkins Agent.
 
 ---
 
-<a href="../src/state.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_agent_relation`
 
@@ -54,7 +54,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_deprecated_agent_relation`
 
@@ -79,7 +79,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L71"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `numeric_executors`
 
@@ -121,6 +121,37 @@ __init__(msg: str)
 ```
 
 Initialize a new instance of the CharmConfigInvalidError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `CharmIllegalNumUnitsError`
+Represents an error with invalid number of units deployed. 
+
+
+
+**Attributes:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+<a href="../src/state.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Initialize a new instance of the CharmIllegalNumUnitsError exception. 
 
 
 
@@ -190,7 +221,7 @@ Configuration for accessing Jenkins through proxy.
 
 ---
 
-<a href="../src/state.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -227,7 +258,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L240"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -254,5 +285,6 @@ Initialize the state from charm.
  
  - <b>`CharmConfigInvalidError`</b>:  if invalid state values were encountered. 
  - <b>`CharmRelationDataInvalidError`</b>:  if invalid relation data was received. 
+ - <b>`CharmIllegalNumUnitsError`</b>:  if more than 1 unit of Jenkins charm is deployed. 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,12 @@ import cos
 import jenkins
 import status
 import timerange
-from state import CharmConfigInvalidError, CharmRelationDataInvalidError, State
+from state import (
+    CharmConfigInvalidError,
+    CharmIllegalNumUnitsError,
+    CharmRelationDataInvalidError,
+    State,
+)
 
 if typing.TYPE_CHECKING:
     from ops.pebble import LayerDict  # pragma: no cover
@@ -39,7 +44,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         super().__init__(*args)
         try:
             self.state = State.from_charm(self)
-        except CharmConfigInvalidError as exc:
+        except (CharmConfigInvalidError, CharmIllegalNumUnitsError) as exc:
             self.unit.status = ops.BlockedStatus(exc.msg)
             return
         except CharmRelationDataInvalidError as exc:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ import jenkinsapi.jenkins
 import pytest
 import requests
 import yaml
+from ops.charm import CharmBase
 from ops.model import Container
 from ops.pebble import ExecError
 from ops.testing import Harness
@@ -440,3 +441,11 @@ def plugin_groovy_script_result_fixture():
         dep-b-b (v0.0.4) => []
         """
     )
+
+
+@pytest.fixture(scope="module", name="mock_charm")
+def mock_charm_fixture():
+    """A valid mock charm."""
+    mock_charm = unittest.mock.MagicMock(spec=CharmBase)
+    mock_charm.app.planned_units.return_value = 1
+    return mock_charm


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Limits the number of units of server charm deployment to 1 since Jenkins does not support multi-controller nodes.

### Rationale

Improve UX on accidental multi-unit deployment

### Juju Events Changes

None.

### Module Changes

state.py changed to check for number of units planned.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->

<img width="806" alt="image" src="https://github.com/canonical/jenkins-k8s-operator/assets/37652070/a3c16ac8-b4a3-4c92-ac83-8f42db28090e">
