### PR TITLE
fix: use api token instaed of password

### DIFF
--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -27,7 +27,7 @@ Functions to operate Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `wait_ready`
 
@@ -53,7 +53,7 @@ Wait until Jenkins service is up.
 
 ---
 
-<a href="../src/jenkins.py#L171"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_admin_credentials`
 
@@ -77,7 +77,7 @@ Retrieve admin credentials.
 
 ---
 
-<a href="../src/jenkins.py#L195"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `calculate_env`
 
@@ -95,7 +95,7 @@ Return a dictionary for Jenkins Pebble layer.
 
 ---
 
-<a href="../src/jenkins.py#L204"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L226"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_version`
 
@@ -119,7 +119,7 @@ Get the Jenkins server version.
 
 ---
 
-<a href="../src/jenkins.py#L377"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L410"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `bootstrap`
 
@@ -145,7 +145,7 @@ Initialize and install Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L414"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L448"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_node_secret`
 
@@ -176,7 +176,7 @@ Get node secret from jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L437"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L471"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `add_agent_node`
 
@@ -202,7 +202,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L462"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L496"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_agent_node`
 
@@ -228,7 +228,7 @@ Remove a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L571"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L605"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_updatable_version`
 
@@ -258,7 +258,7 @@ Get version to update to if available.
 
 ---
 
-<a href="../src/jenkins.py#L600"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L634"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `has_updates_for_lts`
 
@@ -288,7 +288,7 @@ Return whether the Jenkins has a patched LTS update available.
 
 ---
 
-<a href="../src/jenkins.py#L647"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L681"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_jenkins`
 
@@ -320,7 +320,7 @@ Update Jenkins and return the updated version.
 
 ---
 
-<a href="../src/jenkins.py#L714"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L748"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -345,7 +345,7 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
-<a href="../src/jenkins.py#L739"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L773"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_agent_name`
 
@@ -369,7 +369,7 @@ Infer agent name from unit name.
 
 ---
 
-<a href="../src/jenkins.py#L887"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L921"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_unlisted_plugins`
 
@@ -408,7 +408,7 @@ Information needed to log into Jenkins.
 **Attributes:**
  
  - <b>`username`</b>:  The Jenkins account username used to log into Jenkins. 
- - <b>`password`</b>:  The Jenkins account password used to log into Jenkins. 
+ - <b>`password_or_token`</b>:  The Jenkins API token or account password used to log into Jenkins. 
 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -145,7 +145,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             event.defer()
             return
         credentials = jenkins.get_admin_credentials(container)
-        event.set_results({"password": credentials.password})
+        event.set_results({"password": credentials.password_or_token})
 
     def _remove_unlisted_plugins(self, container: ops.Container) -> ops.StatusBase:
         """Remove plugins that are installed but not allowed.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,7 +65,7 @@ def mocked_get_request_fixture(jenkins_version: str):
 @pytest.fixture(scope="function", name="admin_credentials")
 def admin_credentials_fixture() -> jenkins.Credentials:
     """Admin credentials for Jenkins."""
-    return jenkins.Credentials(username="admin", password=token_hex(16))
+    return jenkins.Credentials(username="admin", password_or_token=token_hex(16))
 
 
 @pytest.fixture(scope="function", name="mock_client")
@@ -171,7 +171,9 @@ def container_fixture(
     jenkins_root = harness.get_filesystem_root("jenkins")
     password_file_path = combine_root_paths(jenkins_root, jenkins.PASSWORD_FILE_PATH)
     password_file_path.parent.mkdir(parents=True, exist_ok=True)
-    password_file_path.write_text(admin_credentials.password, encoding="utf-8")
+    password_file_path.write_text(admin_credentials.password_or_token, encoding="utf-8")
+    api_token_file_path = combine_root_paths(jenkins_root, jenkins.API_TOKEN_PATH)
+    api_token_file_path.write_text(admin_credentials.password_or_token, encoding="utf-8")
 
     def cmd_handler(argv: list[str]) -> tuple[int, str, str]:
         """Handle the python command execution inside the Flask container.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -133,6 +133,7 @@ def test__on_jenkins_pebble_ready(  # pylint: disable=too-many-arguments
     monkeypatch.setattr(state.os, "environ", {})
     # speed up waiting by changing default argument values
     monkeypatch.setattr(jenkins.wait_ready, "__defaults__", (1, 1))
+    monkeypatch.setattr(jenkins, "_setup_user_token", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         requests, "get", functools.partial(mocked_get_request, status_code=status_code)
     )
@@ -179,7 +180,9 @@ def test__on_get_admin_password_action(
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     jenkins_charm._on_get_admin_password(mock_event)
 
-    mock_event.set_results.assert_called_once_with({"password": admin_credentials.password})
+    mock_event.set_results.assert_called_once_with(
+        {"password": admin_credentials.password_or_token}
+    )
 
 
 def test__update_jenkins_version_already_latest(


### PR DESCRIPTION
Applicable spec: N/A

### Overview

To use API token instead of insecure password. This is also useful when changing the security realm for Jenkins to non-Jenkins database user authorization, where the password will no longer work while api tokens continue to work.

### Rationale

To keep control of Jenkins even when security realm changes.

### Juju Events Changes

None.

### Module Changes

Added a `_get_api_credentials` in `jenkins.py` alongside `get_admin_credentials` and internal client creator methods now call `_get_api_credentials` instead of `get_admin_credentials`.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
