### PR TITLE
test: refactor raise exceptions lambda

### DIFF
--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -68,6 +68,7 @@ async def test_rotate_password_action(unit_web_client: UnitWebClient):
     assert: the session is invalidated and new password is returned.
     """
     session = unit_web_client.client.requester.session
+    session.auth = (unit_web_client.client.username, unit_web_client.client.password)
     result = session.get(f"{unit_web_client.web}/manage/")
     assert result.status_code == 200, "Unable to access Jenkins with initial credentials."
     action: Action = await unit_web_client.unit.run_action("rotate-credentials")
@@ -76,7 +77,7 @@ async def test_rotate_password_action(unit_web_client: UnitWebClient):
 
     assert unit_web_client.client.password != new_password, "Password not rotated"
     result = session.get(f"{unit_web_client.web}/manage/")
-    assert result.status_code == 403, "Session not cleared"
+    assert result.status_code == 401, "Session not cleared"
     new_client = jenkinsapi.jenkins.Jenkins(unit_web_client.web, "admin", new_password)
     result = new_client.requester.get_url(f"{unit_web_client.web}/manage/")
     assert result.status_code == 200, "Invalid password"

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -68,7 +68,8 @@ async def test_rotate_password_action(unit_web_client: UnitWebClient):
     assert: the session is invalidated and new password is returned.
     """
     session = unit_web_client.client.requester.session
-    session.get(f"{unit_web_client.web}/manage/")
+    result = session.get(f"{unit_web_client.web}/manage/")
+    assert result.status_code == 200, "Unable to access Jenkins with initial credentials."
     action: Action = await unit_web_client.unit.run_action("rotate-credentials")
     await action.wait()
     new_password: str = action.results["password"]

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -317,7 +317,7 @@ async def test_rebuilder_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     job = unit_web_client.client.create_job("rebuild_test", gen_test_job_xml("k8s"))
     job.invoke().block_until_complete()
 
-    unit_web_client.client.requester.get_url(
+    unit_web_client.client.requester.post_url(
         f"{unit_web_client.web}/job/rebuild_test/lastCompletedBuild/rebuild/"
     )
     job.get_last_build().block_until_complete()

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -320,5 +320,6 @@ async def test_rebuilder_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     unit_web_client.client.requester.get_url(
         f"{unit_web_client.web}/job/rebuild_test/lastCompletedBuild/rebuild/"
     )
+    job.get_last_build().block_until_complete()
 
     assert job.get_last_buildnumber() == 2, "Rebuild not triggered."

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -251,11 +251,11 @@ def harness_container_fixture(harness: Harness, container: Container) -> Harness
     return HarnessWithContainer(harness=harness, container=container)
 
 
-@pytest.fixture(scope="function", name="raise_exception")
-def raise_exception_fixture():
+@pytest.fixture(scope="function", name="raise_exception_mock")
+def raise_exception_mock_fixture():
     """The mock function for patching."""
 
-    def raise_exception(exception: Exception):
+    def raise_exception_mock(exception: Exception):
         """Raise exception function for monkeypatching.
 
         Args:
@@ -264,9 +264,11 @@ def raise_exception_fixture():
         Raises:
             exception: .
         """
-        raise exception
+        mock = unittest.mock.MagicMock()
+        mock.side_effect = exception
+        return mock
 
-    return raise_exception
+    return raise_exception_mock
 
 
 @pytest.fixture(scope="function", name="get_relation_data")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -261,8 +261,8 @@ def raise_exception_mock_fixture():
         Args:
             exception: The exception to raise.
 
-        Raises:
-            exception: .
+        Returns:
+            A magic mock that raises an exception when called.
         """
         mock = unittest.mock.MagicMock()
         mock.side_effect = exception

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -79,7 +79,7 @@ def test_on_rotate_credentials_action_container_not_ready(
 def test_on_rotate_credentials_action_api_error(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given a monkeypatched rotate_credentials that raises a JenkinsError.
@@ -89,7 +89,7 @@ def test_on_rotate_credentials_action_api_error(
     monkeypatch.setattr(
         charm.actions.jenkins,
         "rotate_credentials",
-        lambda *_args, **_kwargs: raise_exception(jenkins.JenkinsError),
+        raise_exception_mock(jenkins.JenkinsError),
     )
     harness_container.harness.set_can_connect(
         harness_container.harness.model.unit.containers["jenkins"], True

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -153,7 +153,7 @@ def test__on_agent_relation_joined_relation_data_not_valid(
 )
 def test__on_agent_relation_joined_client_error(
     harness_container: HarnessWithContainer,
-    raise_exception: Callable,
+    raise_exception_mock: Callable,
     monkeypatch: pytest.MonkeyPatch,
     get_relation_data: Callable[[str], dict[str, str]],
     relation: str,
@@ -171,7 +171,7 @@ def test__on_agent_relation_joined_client_error(
     monkeypatch.setattr(
         charm.jenkins,
         "add_agent_node",
-        lambda *_args, **_kwargs: raise_exception(exception=jenkins.JenkinsError()),
+        raise_exception_mock(exception=jenkins.JenkinsError()),
     )
     relation_id = harness_container.harness.add_relation(relation, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")
@@ -289,7 +289,7 @@ def test__on_agent_relation_departed_no_container(
 def test__on_agent_relation_departed_remove_agent_node_error(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,
-    raise_exception: Callable,
+    raise_exception_mock: Callable,
     get_relation_data: Callable[[str], dict[str, str]],
     relation: str,
 ):
@@ -301,7 +301,7 @@ def test__on_agent_relation_departed_remove_agent_node_error(
     monkeypatch.setattr(
         charm.jenkins,
         "remove_agent_node",
-        lambda *_args, **_kwargs: raise_exception(jenkins.JenkinsError),
+        raise_exception_mock(jenkins.JenkinsError),
     )
     relation_id = harness_container.harness.add_relation(relation, "jenkins-agent")
     harness_container.harness.add_relation_unit(relation_id, "jenkins-agent/0")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,7 +96,7 @@ def test__on_jenkins_pebble_ready_get_version_error(
     assert: the unit status should be in BlockedStatus.
     """
     # speed up waiting by changing default argument values
-    monkeypatch.setattr(jenkins, "get_version", lambda: raise_exception_mock(jenkins.JenkinsError))
+    monkeypatch.setattr(jenkins, "get_version", raise_exception_mock(jenkins.JenkinsError))
     monkeypatch.setattr(jenkins.wait_ready, "__defaults__", (1, 1))
     monkeypatch.setattr(jenkins, "bootstrap", lambda *_args: None)
     monkeypatch.setattr(requests, "get", functools.partial(mocked_get_request, status_code=200))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -62,7 +62,7 @@ def test__on_jenkins_pebble_ready_error(
     harness_container: HarnessWithContainer,
     mocked_get_request: typing.Callable[[str, int, typing.Any, typing.Any], requests.Response],
     monkeypatch: pytest.MonkeyPatch,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given a patched jenkins bootstrap method that raises an exception.
@@ -74,7 +74,7 @@ def test__on_jenkins_pebble_ready_error(
     monkeypatch.setattr(
         jenkins,
         "bootstrap",
-        lambda *_args, **_kwargs: raise_exception(jenkins.JenkinsBootstrapError()),
+        raise_exception_mock(jenkins.JenkinsBootstrapError()),
     )
     monkeypatch.setattr(requests, "get", functools.partial(mocked_get_request, status_code=200))
 
@@ -88,7 +88,7 @@ def test__on_jenkins_pebble_ready_get_version_error(
     harness_container: HarnessWithContainer,
     mocked_get_request: typing.Callable[[str, int, typing.Any, typing.Any], requests.Response],
     monkeypatch: pytest.MonkeyPatch,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given a patched jenkins.get_version function that raises an exception.
@@ -96,7 +96,7 @@ def test__on_jenkins_pebble_ready_get_version_error(
     assert: the unit status should be in BlockedStatus.
     """
     # speed up waiting by changing default argument values
-    monkeypatch.setattr(jenkins, "get_version", lambda: raise_exception(jenkins.JenkinsError))
+    monkeypatch.setattr(jenkins, "get_version", lambda: raise_exception_mock(jenkins.JenkinsError))
     monkeypatch.setattr(jenkins.wait_ready, "__defaults__", (1, 1))
     monkeypatch.setattr(jenkins, "bootstrap", lambda *_args: None)
     monkeypatch.setattr(requests, "get", functools.partial(mocked_get_request, status_code=200))
@@ -168,7 +168,7 @@ def test__remove_unlisted_plugins_error(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,
     exception: Exception,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
     expected_status: ops.StatusBase,
 ):
     """
@@ -177,7 +177,9 @@ def test__remove_unlisted_plugins_error(
     assert: ActiveStatus with error message is returned.
     """
     monkeypatch.setattr(
-        jenkins, "remove_unlisted_plugins", lambda *_args, **_kwargs: raise_exception(exception)
+        jenkins,
+        "remove_unlisted_plugins",
+        raise_exception_mock(exception),
     )
     harness_container.harness.begin()
 

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -292,7 +292,7 @@ def test__install_plugins_fail(raise_exception_mock):
     assert: JenkinsPluginError is raised.
     """
     mock_proc = unittest.mock.MagicMock(spec=ExecProcess)
-    mock_proc.wait_output.side_effect = lambda: raise_exception_mock(
+    mock_proc.wait_output.side_effect = raise_exception_mock(
         exception=ExecError(["mock", "command"], 1, "", "Failed to install plugins.")
     )
     mock_container = unittest.mock.MagicMock(spec=ops.Container)
@@ -326,7 +326,7 @@ def test__configure_proxy_fail(
     """
     mock_client.run_groovy_script = raise_exception_mock(
         exception=jenkinsapi.custom_exceptions.JenkinsAPIException
-    )raise_exception_mock
+    )
 
     with pytest.raises(jenkins.JenkinsProxyError) as exc:
         jenkins._configure_proxy(harness_container.container, proxy_config)
@@ -424,7 +424,7 @@ def test_bootstrap_fail(
     monkeypatch.setattr(
         jenkins,
         "_install_plugins",
-        lambda *_args, **kwargs: raise_exception_mock(exception=jenkins.JenkinsPluginError),
+        raise_exception_mock(exception=jenkins.JenkinsPluginError),
     )
 
     with pytest.raises(jenkins.JenkinsBootstrapError):
@@ -628,9 +628,7 @@ def test__wait_jenkins_job_shutdown_timeout(monkeypatch: pytest.MonkeyPatch, rai
     act: when _wait_jenkins_job_shutdown is called.
     assert: TimeoutError is raised.
     """
-    monkeypatch.setattr(
-        jenkins, "_is_shutdown", lambda *_args, **kwargs: raise_exception_mock(TimeoutError)
-    )
+    monkeypatch.setattr(jenkins, "_is_shutdown", raise_exception_mock(TimeoutError))
     mock_client = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins)
 
     with pytest.raises(TimeoutError):
@@ -1013,10 +1011,8 @@ def test_remove_unlisted_plugins_restart_error(  # pylint: disable=too-many-argu
         )
     )
     mock_groovy_script.return_value = plugin_groovy_script_result
-    monkeypatch.setattr(
-        jenkins, "safe_restart", raise_exception_mock(expected_exception)
-    )
-raise_exception_mock
+    monkeypatch.setattr(jenkins, "safe_restart", raise_exception_mock(expected_exception))
+
     # mypy doesn't understand that Exception type can match TypeVar("E", bound=BaseException)
     with pytest.raises(expected_exception):  # type: ignore
         jenkins.remove_unlisted_plugins(("plugin-a", "plugin-b"), container)
@@ -1121,9 +1117,7 @@ def test_rotate_credentials_error(
     monkeypatch.setattr(
         jenkins,
         "_invalidate_sessions",
-        raise_exception_mock(
-            jenkinsapi.custom_exceptions.JenkinsAPIException
-        raise_exception_mock
+        raise_exception_mock(jenkinsapi.custom_exceptions.JenkinsAPIException),
     )
 
     with pytest.raises(jenkins.JenkinsError):

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -151,16 +151,14 @@ def test_calculate_env():
     ],
 )
 def test_get_version_error(
-    monkeypatch: pytest.MonkeyPatch, raise_exception: typing.Callable, exception: Exception
+    monkeypatch: pytest.MonkeyPatch, raise_exception_mock: typing.Callable, exception: Exception
 ):
     """
     arrange: given a monkeypatched request that raises exceptions.
     act: when a request is sent to Jenkins server.
     assert: JenkinsError exception is raised.
     """
-    monkeypatch.setattr(
-        jenkins.requests, "get", lambda *_args, **_kwargs: raise_exception(exception)
-    )
+    monkeypatch.setattr(jenkins.requests, "get", raise_exception_mock(exception))
 
     with pytest.raises(jenkins.JenkinsError):
         jenkins.get_version()
@@ -287,14 +285,14 @@ def test__get_java_proxy_args(
     assert tuple(jenkins._get_java_proxy_args(proxy_config)) == expected_args
 
 
-def test__install_plugins_fail(raise_exception):
+def test__install_plugins_fail(raise_exception_mock):
     """
     arrange: given a mocked container with a mocked failing process.
     act: when _install_plugins is called.
     assert: JenkinsPluginError is raised.
     """
     mock_proc = unittest.mock.MagicMock(spec=ExecProcess)
-    mock_proc.wait_output.side_effect = lambda: raise_exception(
+    mock_proc.wait_output.side_effect = lambda: raise_exception_mock(
         exception=ExecError(["mock", "command"], 1, "", "Failed to install plugins.")
     )
     mock_container = unittest.mock.MagicMock(spec=ops.Container)
@@ -319,16 +317,16 @@ def test__configure_proxy_fail(
     harness_container: HarnessWithContainer,
     proxy_config: state.ProxyConfig,
     mock_client: unittest.mock.MagicMock,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given a test proxy config and a monkeypatched jenkins client that raises an exception.
     act: when _configure_proxy is called.
     assert: JenkinsProxyError is raised.
     """
-    mock_client.run_groovy_script = lambda *_args, **_kwargs: raise_exception(
+    mock_client.run_groovy_script = raise_exception_mock(
         exception=jenkinsapi.custom_exceptions.JenkinsAPIException
-    )
+    )raise_exception_mock
 
     with pytest.raises(jenkins.JenkinsProxyError) as exc:
         jenkins._configure_proxy(harness_container.container, proxy_config)
@@ -414,7 +412,7 @@ def test_bootstrap_fail(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,
     jenkins_version: str,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given mocked container, monkeypatched get_version function and invalid plugins to \
@@ -426,7 +424,7 @@ def test_bootstrap_fail(
     monkeypatch.setattr(
         jenkins,
         "_install_plugins",
-        lambda *_args, **kwargs: raise_exception(exception=jenkins.JenkinsPluginError),
+        lambda *_args, **kwargs: raise_exception_mock(exception=jenkins.JenkinsPluginError),
     )
 
     with pytest.raises(jenkins.JenkinsBootstrapError):
@@ -624,14 +622,14 @@ def test__is_shutdown_service_unavailable(mock_client: unittest.mock.MagicMock):
     assert jenkins._is_shutdown(mock_client)
 
 
-def test__wait_jenkins_job_shutdown_timeout(monkeypatch: pytest.MonkeyPatch, raise_exception):
+def test__wait_jenkins_job_shutdown_timeout(monkeypatch: pytest.MonkeyPatch, raise_exception_mock):
     """
     arrange: given a patched _is_shutdown request that raises a TimeoutError.
     act: when _wait_jenkins_job_shutdown is called.
     assert: TimeoutError is raised.
     """
     monkeypatch.setattr(
-        jenkins, "_is_shutdown", lambda *_args, **kwargs: raise_exception(TimeoutError)
+        jenkins, "_is_shutdown", lambda *_args, **kwargs: raise_exception_mock(TimeoutError)
     )
     mock_client = unittest.mock.MagicMock(spec=jenkinsapi.jenkins.Jenkins)
 
@@ -1001,7 +999,7 @@ def test_remove_unlisted_plugins_restart_error(  # pylint: disable=too-many-argu
     mock_client: unittest.mock.MagicMock,
     container: ops.Container,
     plugin_groovy_script_result: str,
-    raise_exception: typing.Callable,
+    raise_exception_mock: typing.Callable,
     expected_exception: Exception,
 ):
     """
@@ -1016,9 +1014,9 @@ def test_remove_unlisted_plugins_restart_error(  # pylint: disable=too-many-argu
     )
     mock_groovy_script.return_value = plugin_groovy_script_result
     monkeypatch.setattr(
-        jenkins, "safe_restart", lambda *_args, **_kwargs: raise_exception(expected_exception)
+        jenkins, "safe_restart", raise_exception_mock(expected_exception)
     )
-
+raise_exception_mock
     # mypy doesn't understand that Exception type can match TypeVar("E", bound=BaseException)
     with pytest.raises(expected_exception):  # type: ignore
         jenkins.remove_unlisted_plugins(("plugin-a", "plugin-b"), container)
@@ -1111,7 +1109,9 @@ def test_remove_unlisted_plugins(  # pylint: disable=too-many-arguments
 
 
 def test_rotate_credentials_error(
-    monkeypatch: pytest.MonkeyPatch, container: ops.Container, raise_exception: typing.Callable
+    monkeypatch: pytest.MonkeyPatch,
+    container: ops.Container,
+    raise_exception_mock: typing.Callable,
 ):
     """
     arrange: given a monkeypatched _invalidate_sessions that raises JenkinsAPIException.
@@ -1121,9 +1121,9 @@ def test_rotate_credentials_error(
     monkeypatch.setattr(
         jenkins,
         "_invalidate_sessions",
-        lambda *_args, **_kwargs: raise_exception(
+        raise_exception_mock(
             jenkinsapi.custom_exceptions.JenkinsAPIException
-        ),
+        raise_exception_mock
     )
 
     with pytest.raises(jenkins.JenkinsError):


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Refactor raising exceptions via lambda to `unittest.mock`'s `side_effect` function.

### Rationale

Use Pythonic testing syntax.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
