### PR TITLE
fix: juju 3.1 compatible cos stack

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,7 +8,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.26-strict/stable
+      channel: 1.28-strict/stable
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
       modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,11 +8,11 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      extra-arguments: |
+        --kube-config ${GITHUB_WORKSPACE}/kube-config
+      modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
       pre-run-script: |
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
         chmod +x tests/integration/pre_run_script.sh
         ./tests/integration/pre_run_script.sh"
-      extra-arguments: |
-        --kube-config ${GITHUB_WORKSPACE}/kube-config
-      modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
-
+      juju-channel: 3.1/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,6 +8,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      channel: 1.26-strict/stable
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
       modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jenkinsapi>=0.3,<1
 ops>=2,<3
 pydantic>=1,<2
 requests>=2,<3
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ jenkinsapi>=0.3,<1
 ops>=2,<3
 pydantic>=1,<2
 requests>=2,<3
-jsonschema

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -591,9 +591,7 @@ async def ldap_server_ip_fixture(
 @pytest_asyncio.fixture(scope="module", name="prometheus_related")
 async def prometheus_related_fixture(application: Application, model: Model):
     """The prometheus-k8s application related to Jenkins via metrics-endpoint relation."""
-    prometheus = await model.deploy(
-        "prometheus-k8s", channel="1.0/stable", trust=True, revision=129, series="focal"
-    )
+    prometheus = await model.deploy("prometheus-k8s", channel="1.0/stable", trust=True)
     await model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
@@ -611,9 +609,7 @@ async def prometheus_related_fixture(application: Application, model: Model):
 @pytest_asyncio.fixture(scope="module", name="loki_related")
 async def loki_related_fixture(application: Application, model: Model):
     """The loki-k8s application related to Jenkins via logging relation."""
-    loki = await model.deploy(
-        "loki-k8s", channel="1.0/stable", trust=True, revision=91, series="focal"
-    )
+    loki = await model.deploy("loki-k8s", channel="1.0/stable", trust=True)
     await model.wait_for_idle(
         status="active", apps=[loki.name], raise_on_error=False, timeout=30 * 60
     )
@@ -631,9 +627,7 @@ async def loki_related_fixture(application: Application, model: Model):
 @pytest_asyncio.fixture(scope="module", name="grafana_related")
 async def grafana_related_fixture(application: Application, model: Model):
     """The grafana-k8s application related to Jenkins via grafana-dashboard relation."""
-    grafana = await model.deploy(
-        "grafana-k8s", channel="1.0/stable", trust=True, revision=82, series="focal"
-    )
+    grafana = await model.deploy("grafana-k8s", channel="1.0/stable", trust=True)
     await model.wait_for_idle(
         status="active", apps=[grafana.name], raise_on_error=False, timeout=30 * 60
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -172,7 +172,7 @@ async def jenkins_k8s_agents_fixture(
 
     yield agent_app
 
-    await model.remove_application(agent_app.name, block_until_done=True, force=True)
+    await model.remove_application(agent_app.name, block_until_done=True)
 
 
 @pytest_asyncio.fixture(scope="function", name="k8s_agent_related_app")
@@ -474,7 +474,7 @@ async def jenkins_with_proxy_fixture(
     async with ops_test.fast_forward(fast_interval="5h"):
         yield application
 
-    await model_with_proxy.remove_application(application.name, force=True, block_until_done=True)
+    await model_with_proxy.remove_application(application.name, block_until_done=True)
 
 
 @pytest_asyncio.fixture(scope="module", name="proxy_jenkins_unit_ip")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -592,7 +592,7 @@ async def ldap_server_ip_fixture(
 async def prometheus_related_fixture(application: Application, model: Model):
     """The prometheus-k8s application related to Jenkins via metrics-endpoint relation."""
     prometheus = await model.deploy(
-        "prometheus-k8s", channel="1.0/stable", trust=True, revision=129
+        "prometheus-k8s", channel="1.0/stable", trust=True, revision=129, series="focal"
     )
     await model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
@@ -611,7 +611,9 @@ async def prometheus_related_fixture(application: Application, model: Model):
 @pytest_asyncio.fixture(scope="module", name="loki_related")
 async def loki_related_fixture(application: Application, model: Model):
     """The loki-k8s application related to Jenkins via logging relation."""
-    loki = await model.deploy("loki-k8s", channel="1.0/stable", trust=True, revision=91)
+    loki = await model.deploy(
+        "loki-k8s", channel="1.0/stable", trust=True, revision=91, series="focal"
+    )
     await model.wait_for_idle(
         status="active", apps=[loki.name], raise_on_error=False, timeout=30 * 60
     )
@@ -629,7 +631,9 @@ async def loki_related_fixture(application: Application, model: Model):
 @pytest_asyncio.fixture(scope="module", name="grafana_related")
 async def grafana_related_fixture(application: Application, model: Model):
     """The grafana-k8s application related to Jenkins via grafana-dashboard relation."""
-    grafana = await model.deploy("grafana-k8s", channel="1.0/stable", trust=True, revision=82)
+    grafana = await model.deploy(
+        "grafana-k8s", channel="1.0/stable", trust=True, revision=82, series="focal"
+    )
     await model.wait_for_idle(
         status="active", apps=[grafana.name], raise_on_error=False, timeout=30 * 60
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -591,7 +591,9 @@ async def ldap_server_ip_fixture(
 @pytest_asyncio.fixture(scope="module", name="prometheus_related")
 async def prometheus_related_fixture(application: Application):
     """The prometheus-k8s application related to Jenkins via metrics-endpoint relation."""
-    prometheus = await application.model.deploy("prometheus-k8s", channel="1.0/stable", trust=True)
+    prometheus = await application.model.deploy(
+        "prometheus-k8s", channel="1.0/stable", trust=True, revision=129
+    )
     await application.model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
@@ -609,7 +611,9 @@ async def prometheus_related_fixture(application: Application):
 @pytest_asyncio.fixture(scope="module", name="loki_related")
 async def loki_related_fixture(application: Application):
     """The loki-k8s application related to Jenkins via logging relation."""
-    loki = await application.model.deploy("loki-k8s", channel="1.0/stable", trust=True)
+    loki = await application.model.deploy(
+        "loki-k8s", channel="1.0/stable", trust=True, revision=91
+    )
     await application.model.wait_for_idle(
         status="active", apps=[loki.name], raise_on_error=False, timeout=30 * 60
     )
@@ -627,7 +631,9 @@ async def loki_related_fixture(application: Application):
 @pytest_asyncio.fixture(scope="module", name="grafana_related")
 async def grafana_related_fixture(application: Application):
     """The grafana-k8s application related to Jenkins via grafana-dashboard relation."""
-    grafana = await application.model.deploy("grafana-k8s", channel="1.0/stable", trust=True)
+    grafana = await application.model.deploy(
+        "grafana-k8s", channel="1.0/stable", trust=True, revision=82
+    )
     await application.model.wait_for_idle(
         status="active", apps=[grafana.name], raise_on_error=False, timeout=30 * 60
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -589,16 +589,16 @@ async def ldap_server_ip_fixture(
 
 
 @pytest_asyncio.fixture(scope="module", name="prometheus_related")
-async def prometheus_related_fixture(application: Application):
+async def prometheus_related_fixture(application: Application, model: Model):
     """The prometheus-k8s application related to Jenkins via metrics-endpoint relation."""
-    prometheus = await application.model.deploy(
+    prometheus = await model.deploy(
         "prometheus-k8s", channel="1.0/stable", trust=True, revision=129
     )
-    await application.model.wait_for_idle(
+    await model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
-    await application.model.add_relation(f"{application.name}:metrics-endpoint", prometheus.name)
-    await application.model.wait_for_idle(
+    await model.add_relation(f"{application.name}:metrics-endpoint", prometheus.name)
+    await model.wait_for_idle(
         status="active",
         apps=[prometheus.name, application.name],
         timeout=20 * 60,
@@ -609,16 +609,14 @@ async def prometheus_related_fixture(application: Application):
 
 
 @pytest_asyncio.fixture(scope="module", name="loki_related")
-async def loki_related_fixture(application: Application):
+async def loki_related_fixture(application: Application, model: Model):
     """The loki-k8s application related to Jenkins via logging relation."""
-    loki = await application.model.deploy(
-        "loki-k8s", channel="1.0/stable", trust=True, revision=91
-    )
-    await application.model.wait_for_idle(
+    loki = await model.deploy("loki-k8s", channel="1.0/stable", trust=True, revision=91)
+    await model.wait_for_idle(
         status="active", apps=[loki.name], raise_on_error=False, timeout=30 * 60
     )
-    await application.model.add_relation(f"{application.name}:logging", loki.name)
-    await application.model.wait_for_idle(
+    await model.add_relation(f"{application.name}:logging", loki.name)
+    await model.wait_for_idle(
         status="active",
         apps=[loki.name, application.name],
         timeout=20 * 60,
@@ -629,16 +627,14 @@ async def loki_related_fixture(application: Application):
 
 
 @pytest_asyncio.fixture(scope="module", name="grafana_related")
-async def grafana_related_fixture(application: Application):
+async def grafana_related_fixture(application: Application, model: Model):
     """The grafana-k8s application related to Jenkins via grafana-dashboard relation."""
-    grafana = await application.model.deploy(
-        "grafana-k8s", channel="1.0/stable", trust=True, revision=82
-    )
-    await application.model.wait_for_idle(
+    grafana = await model.deploy("grafana-k8s", channel="1.0/stable", trust=True, revision=82)
+    await model.wait_for_idle(
         status="active", apps=[grafana.name], raise_on_error=False, timeout=30 * 60
     )
-    await application.model.add_relation(f"{application.name}:grafana-dashboard", grafana.name)
-    await application.model.wait_for_idle(
+    await model.add_relation(f"{application.name}:grafana-dashboard", grafana.name)
+    await model.wait_for_idle(
         status="active",
         apps=[grafana.name, application.name],
         timeout=20 * 60,

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -13,8 +13,8 @@ TESTING_MODEL="$(juju switch)"
 
 # lxd should be install and init by a previous step in integration test action.
 echo "bootstrapping lxd juju controller"
-sg microk8s -c "microk8s status --wait-ready"
-sg microk8s -c "juju bootstrap localhost localhost"
+sg snap_microk8s -c "microk8s status --wait-ready"
+sg snap_microk8s -c "juju bootstrap localhost localhost"
 
 echo "Switching to testing model"
-sg microk8s -c "juju switch $TESTING_MODEL"
+sg snap_microk8s -c "juju switch $TESTING_MODEL"

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -48,14 +48,14 @@ async def test_jenkins_automatic_update_out_of_range(
     """
     extra_plugin = "oic-auth"
     await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, (extra_plugin,))
-    ret_code, _, stderr = await ops_test.juju(
-        "run",
-        "--unit",
-        unit_web_client.unit.name,
-        "--",
-        f"{' '.join(libfaketime_env)} {' '.join(update_status_env)} ./dispatch",
+    action: Action = await unit_web_client.unit.run(
+        f"-- {' '.join(libfaketime_env)} {' '.join(update_status_env)} ./dispatch"
     )
-    assert not ret_code, f"Failed to execute update-status-hook, {stderr}"
+    await action.wait()
+    assert (
+        action.status == "completed"
+    ), f"Failed to execute update-status-hook, {action.data['message']}"
+
     assert unit_web_client.client.has_plugin(
         extra_plugin
     ), "additionally installed plugin cleanedup."

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju==3.0.4
+    juju==2.9.45.0
     ops
     pytest-operator
     pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju==2.9.45.0
+    juju>=3,<4
     ops
     pytest-operator
     pytest-asyncio


### PR DESCRIPTION
Applicable spec: N/A

### Overview

To fix integration tests that rely on juju 2.9, the latest COS is not backwards compatible with juju 2.9.

### Rationale

Our operator workflows use juju 2.9 and many of the prod environments are in 2.9.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
