### PR TITLE
chore: install jsonschema binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops>=2,<3
 pydantic>=1,<2
 requests>=2,<3
 # charmcraft pack fails to build, hence install binary
-jsonschema --only-binary=:all:
+jsonschema --only-binary=jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ jenkinsapi>=0.3,<1
 ops>=2,<3
 pydantic>=1,<2
 requests>=2,<3
+# charmcraft pack fails to build, hence install binary
+jsonschema --only-binary=:all:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add jsonschema binary in pip install (binary because chamcraft fails to build it), to suppress runtime warning:
```
The `ingress` library needs the `jsonschema` package to be able to do runtime data validation; without it, it will still work but validation will be disabled. It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, which will enable this feature."
```

### Rationale

To not print the warning which might affect UX.

### Juju Events Changes

None.

### Module Changes

requirements.txt

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
