### PR TITLE
fix: prevent hooks before preconditions ready

### DIFF
--- a/src-docs/actions.py.md
+++ b/src-docs/actions.py.md
@@ -5,6 +5,9 @@
 # <kbd>module</kbd> `actions.py`
 Jenkins charm actions. 
 
+**Global Variables**
+---------------
+- **JENKINS_SERVICE_NAME**
 
 
 ---
@@ -12,12 +15,12 @@ Jenkins charm actions.
 ## <kbd>class</kbd> `Observer`
 Jenkins-k8s charm actions observer. 
 
-<a href="../src/actions.py#L20"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: 'JenkinsK8sOperatorCharm', state: State)
+__init__(charm: CharmBase, state: State)
 ```
 
 Initialize the observer and register actions handlers. 
@@ -40,7 +43,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/actions.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `on_get_admin_password`
 
@@ -58,7 +61,7 @@ Handle get-admin-password event.
 
 ---
 
-<a href="../src/actions.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L45"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `on_rotate_credentials`
 

--- a/src-docs/actions.py.md
+++ b/src-docs/actions.py.md
@@ -12,12 +12,12 @@ Jenkins charm actions.
 ## <kbd>class</kbd> `Observer`
 Jenkins-k8s charm actions observer. 
 
-<a href="../src/actions.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L20"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: CharmBase, state: State)
+__init__(charm: 'JenkinsK8sOperatorCharm', state: State)
 ```
 
 Initialize the observer and register actions handlers. 
@@ -40,7 +40,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/actions.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `on_get_admin_password`
 
@@ -58,7 +58,7 @@ Handle get-admin-password event.
 
 ---
 
-<a href="../src/actions.py#L45"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/actions.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `on_rotate_credentials`
 

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -9,6 +9,7 @@ The Jenkins agent relation observer.
 ---------------
 - **AGENT_RELATION**
 - **DEPRECATED_AGENT_RELATION**
+- **JENKINS_SERVICE_NAME**
 
 
 ---
@@ -32,12 +33,12 @@ Relation data required for adding the Jenkins agent.
 ## <kbd>class</kbd> `Observer`
 The Jenkins agent relation observer. 
 
-<a href="../src/agent.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/agent.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: 'JenkinsK8sOperatorCharm', state: State)
+__init__(charm: CharmBase, state: State)
 ```
 
 Initialize the observer and register event handlers. 

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -32,12 +32,12 @@ Relation data required for adding the Jenkins agent.
 ## <kbd>class</kbd> `Observer`
 The Jenkins agent relation observer. 
 
-<a href="../src/agent.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/agent.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: CharmBase, state: State)
+__init__(charm: 'JenkinsK8sOperatorCharm', state: State)
 ```
 
 Initialize the observer and register event handlers. 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,7 +12,13 @@ Charm Jenkins.
 ## <kbd>class</kbd> `JenkinsK8sOperatorCharm`
 Charm Jenkins. 
 
-<a href="../src/charm.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+
+**Attributes:**
+ 
+ - <b>`is_storage_ready`</b>:  Whether the Jenkins home storage is mounted. 
+
+<a href="../src/charm.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -52,6 +58,17 @@ Root directory of the charm as it is running.
 #### <kbd>property</kbd> config
 
 A mapping containing the charm's config and current values. 
+
+---
+
+#### <kbd>property</kbd> is_storage_ready
+
+Return whether the Jenkins home storage is mounted. 
+
+
+
+**Returns:**
+  True if storage is mounted, False otherwise. 
 
 ---
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -5,6 +5,9 @@
 # <kbd>module</kbd> `charm.py`
 Charm Jenkins. 
 
+**Global Variables**
+---------------
+- **JENKINS_SERVICE_NAME**
 
 
 ---
@@ -12,13 +15,7 @@ Charm Jenkins.
 ## <kbd>class</kbd> `JenkinsK8sOperatorCharm`
 Charm Jenkins. 
 
-
-
-**Attributes:**
- 
- - <b>`is_storage_ready`</b>:  Whether the Jenkins home storage is mounted. 
-
-<a href="../src/charm.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -58,17 +55,6 @@ Root directory of the charm as it is running.
 #### <kbd>property</kbd> config
 
 A mapping containing the charm's config and current values. 
-
----
-
-#### <kbd>property</kbd> is_storage_ready
-
-Return whether the Jenkins home storage is mounted. 
-
-
-
-**Returns:**
-  True if storage is mounted, False otherwise. 
 
 ---
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -252,13 +252,14 @@ The Jenkins k8s operator charm state.
  - <b>`proxy_config`</b>:  Proxy configuration to access Jenkins upstream through. 
  - <b>`plugins`</b>:  The list of allowed plugins to install. 
  - <b>`jenkins_service_name`</b>:  The Jenkins service name. Note that the container name is the same. 
+ - <b>`storage_name`</b>:  The Jenkins home storage name. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L240"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L242"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -12,29 +12,6 @@ Jenkins States.
 - **JENKINS_SERVICE_NAME**
 - **JENKINS_HOME_STORAGE_NAME**
 
----
-
-<a href="../src/state.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>function</kbd> `is_storage_ready`
-
-```python
-is_storage_ready(charm: CharmBase) → bool
-```
-
-Return whether the Jenkins home storage is mounted. 
-
-
-
-**Args:**
- 
- - <b>`charm`</b>:  The Jenkins k8s charm. 
-
-
-
-**Returns:**
- True if storage is mounted, False otherwise. 
-
 
 ---
 
@@ -54,7 +31,7 @@ Metadata for registering Jenkins Agent.
 
 ---
 
-<a href="../src/state.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_agent_relation`
 
@@ -79,7 +56,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_deprecated_agent_relation`
 
@@ -104,7 +81,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `numeric_executors`
 
@@ -137,7 +114,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -168,7 +145,7 @@ Represents an error with invalid number of units deployed.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L68"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -199,7 +176,7 @@ Represents an error with invalid data in relation data.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L53"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -246,7 +223,7 @@ Configuration for accessing Jenkins through proxy.
 
 ---
 
-<a href="../src/state.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L203"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -283,7 +260,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L259"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L260"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -9,6 +9,31 @@ Jenkins States.
 ---------------
 - **AGENT_RELATION**
 - **DEPRECATED_AGENT_RELATION**
+- **JENKINS_SERVICE_NAME**
+- **JENKINS_HOME_STORAGE_NAME**
+
+---
+
+<a href="../src/state.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `is_storage_ready`
+
+```python
+is_storage_ready(charm: CharmBase) → bool
+```
+
+Return whether the Jenkins home storage is mounted. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The Jenkins k8s charm. 
+
+
+
+**Returns:**
+ True if storage is mounted, False otherwise. 
 
 
 ---
@@ -29,7 +54,7 @@ Metadata for registering Jenkins Agent.
 
 ---
 
-<a href="../src/state.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_agent_relation`
 
@@ -54,7 +79,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_deprecated_agent_relation`
 
@@ -79,7 +104,7 @@ Instantiate AgentMeta from charm relation databag.
 
 ---
 
-<a href="../src/state.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `numeric_executors`
 
@@ -112,7 +137,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -143,7 +168,7 @@ Represents an error with invalid number of units deployed.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L68"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -174,7 +199,7 @@ Represents an error with invalid data in relation data.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -221,7 +246,7 @@ Configuration for accessing Jenkins through proxy.
 
 ---
 
-<a href="../src/state.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -249,17 +274,16 @@ The Jenkins k8s operator charm state.
  - <b>`restart_time_range`</b>:  Time range to allow Jenkins to update version. 
  - <b>`agent_relation_meta`</b>:  Metadata of all agents from units related through agent relation. 
  - <b>`deprecated_agent_relation_meta`</b>:  Metadata of all agents from units related through  deprecated agent relation. 
+ - <b>`is_storage_ready`</b>:  Whether the Jenkins home storage is mounted. 
  - <b>`proxy_config`</b>:  Proxy configuration to access Jenkins upstream through. 
  - <b>`plugins`</b>:  The list of allowed plugins to install. 
- - <b>`jenkins_service_name`</b>:  The Jenkins service name. Note that the container name is the same. 
- - <b>`storage_name`</b>:  The Jenkins home storage name. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L242"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L259"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -36,8 +36,8 @@ class Observer(ops.Object):
             event: The event fired from get-admin-password action.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.fail("Container not yet ready.")
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+            event.fail("Service not yet ready.")
             return
         credentials = jenkins.get_admin_credentials(container)
         event.set_results({"password": credentials.password_or_token})
@@ -49,8 +49,8 @@ class Observer(ops.Object):
             event: The rotate credentials event.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.fail("Container not yet ready.")
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+            event.fail("Service not yet ready.")
             return
         try:
             password = jenkins.rotate_credentials(container)

--- a/src/actions.py
+++ b/src/actions.py
@@ -3,21 +3,16 @@
 
 """Jenkins charm actions."""
 
-import typing
-
 import ops
 
 import jenkins
-from state import State
-
-if typing.TYPE_CHECKING:
-    from charm import JenkinsK8sOperatorCharm  # pragma: no cover
+from state import JENKINS_SERVICE_NAME, State
 
 
 class Observer(ops.Object):
     """Jenkins-k8s charm actions observer."""
 
-    def __init__(self, charm: "JenkinsK8sOperatorCharm", state: State):
+    def __init__(self, charm: ops.CharmBase, state: State):
         """Initialize the observer and register actions handlers.
 
         Args:
@@ -40,8 +35,8 @@ class Observer(ops.Object):
         Args:
             event: The event fired from get-admin-password action.
         """
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             event.fail("Service not yet ready.")
             return
         credentials = jenkins.get_admin_credentials(container)
@@ -53,8 +48,8 @@ class Observer(ops.Object):
         Args:
             event: The rotate credentials event.
         """
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             event.fail("Service not yet ready.")
             return
         try:

--- a/src/actions.py
+++ b/src/actions.py
@@ -3,16 +3,21 @@
 
 """Jenkins charm actions."""
 
+import typing
+
 import ops
 
 import jenkins
 from state import State
 
+if typing.TYPE_CHECKING:
+    from charm import JenkinsK8sOperatorCharm  # pragma: no cover
+
 
 class Observer(ops.Object):
     """Jenkins-k8s charm actions observer."""
 
-    def __init__(self, charm: ops.CharmBase, state: State):
+    def __init__(self, charm: "JenkinsK8sOperatorCharm", state: State):
         """Initialize the observer and register actions handlers.
 
         Args:
@@ -36,7 +41,7 @@ class Observer(ops.Object):
             event: The event fired from get-admin-password action.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             event.fail("Service not yet ready.")
             return
         credentials = jenkins.get_admin_credentials(container)
@@ -49,7 +54,7 @@ class Observer(ops.Object):
             event: The rotate credentials event.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             event.fail("Service not yet ready.")
             return
         try:

--- a/src/agent.py
+++ b/src/agent.py
@@ -61,8 +61,7 @@ class Observer(ops.Object):
             event: The event fired from an agent joining the relationship.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.defer()
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -101,8 +100,7 @@ class Observer(ops.Object):
             event: The event fired from an agent joining the relationship.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.defer()
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -145,8 +143,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.defer()
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -173,8 +170,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            event.defer()
+        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -8,10 +8,7 @@ import typing
 import ops
 
 import jenkins
-from state import AGENT_RELATION, DEPRECATED_AGENT_RELATION, AgentMeta, State
-
-if typing.TYPE_CHECKING:
-    from charm import JenkinsK8sOperatorCharm  # pragma: no cover
+from state import AGENT_RELATION, DEPRECATED_AGENT_RELATION, JENKINS_SERVICE_NAME, AgentMeta, State
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +28,7 @@ class AgentRelationData(typing.TypedDict):
 class Observer(ops.Object):
     """The Jenkins agent relation observer."""
 
-    def __init__(self, charm: "JenkinsK8sOperatorCharm", state: State):
+    def __init__(self, charm: ops.CharmBase, state: State):
         """Initialize the observer and register event handlers.
 
         Args:
@@ -63,8 +60,8 @@ class Observer(ops.Object):
         Args:
             event: The event fired from an agent joining the relationship.
         """
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -102,8 +99,8 @@ class Observer(ops.Object):
         Args:
             event: The event fired from an agent joining the relationship.
         """
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -145,8 +142,8 @@ class Observer(ops.Object):
             event: The event fired when a unit in deprecated agent relation is departed.
         """
         # the event unit cannot be None.
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -172,8 +169,8 @@ class Observer(ops.Object):
             event: The event fired when a unit in agent relation is departed.
         """
         # the event unit cannot be None.
-        container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.charm.is_storage_ready:
+        container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -10,6 +10,9 @@ import ops
 import jenkins
 from state import AGENT_RELATION, DEPRECATED_AGENT_RELATION, AgentMeta, State
 
+if typing.TYPE_CHECKING:
+    from charm import JenkinsK8sOperatorCharm  # pragma: no cover
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,7 +31,7 @@ class AgentRelationData(typing.TypedDict):
 class Observer(ops.Object):
     """The Jenkins agent relation observer."""
 
-    def __init__(self, charm: ops.CharmBase, state: State):
+    def __init__(self, charm: "JenkinsK8sOperatorCharm", state: State):
         """Initialize the observer and register event handlers.
 
         Args:
@@ -61,7 +64,7 @@ class Observer(ops.Object):
             event: The event fired from an agent joining the relationship.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -100,7 +103,7 @@ class Observer(ops.Object):
             event: The event fired from an agent joining the relationship.
         """
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -143,7 +146,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -170,7 +173,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.model.storages.get(self.state.storage_name):
+        if not container.can_connect() or not self.charm.is_storage_ready:
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ import ingress
 import jenkins
 import timerange
 from state import (
+    JENKINS_SERVICE_NAME,
     CharmConfigInvalidError,
     CharmIllegalNumUnitsError,
     CharmRelationDataInvalidError,
@@ -31,11 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class JenkinsK8sOperatorCharm(ops.CharmBase):
-    """Charm Jenkins.
-
-    Attributes:
-        is_storage_ready: Whether the Jenkins home storage is mounted.
-    """
+    """Charm Jenkins."""
 
     def __init__(self, *args: typing.Any):
         """Initialize the charm and register event handlers.
@@ -65,19 +62,6 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on.jenkins_pebble_ready, self._on_jenkins_pebble_ready)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
-    @property
-    def is_storage_ready(self) -> bool:
-        """Return whether the Jenkins home storage is mounted.
-
-        Returns:
-            True if storage is mounted, False otherwise.
-        """
-        container = self.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect():
-            return False
-        mount_info: str = container.pull("/proc/mounts").read()
-        return str(jenkins.HOME_PATH) in mount_info
-
     def _get_pebble_layer(self, jenkins_env: jenkins.Environment) -> ops.pebble.Layer:
         """Return a dictionary representing a Pebble layer.
 
@@ -91,7 +75,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             "summary": "jenkins layer",
             "description": "pebble config layer for jenkins",
             "services": {
-                self.state.jenkins_service_name: {
+                JENKINS_SERVICE_NAME: {
                     "override": "replace",
                     "summary": "jenkins",
                     "command": f"java -D{jenkins.SYSTEM_PROPERTY_HEADLESS} "
@@ -122,8 +106,8 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         Args:
             event: The event fired when pebble is ready.
         """
-        container = self.unit.get_container(self.state.jenkins_service_name)
-        if not container or not container.can_connect() or not self.is_storage_ready:
+        container = self.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container or not container.can_connect() or not self.state.is_storage_ready:
             self.unit.status = ops.WaitingStatus("Waiting for container/storage.")
             event.defer()
             return
@@ -141,7 +125,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus("Configuring Jenkins.")
             jenkins.bootstrap(container, self.state.proxy_config)
             # Second Jenkins server start restarts Jenkins to bypass Wizard setup.
-            container.restart(self.state.jenkins_service_name)
+            container.restart(JENKINS_SERVICE_NAME)
             jenkins.wait_ready()
         except TimeoutError as exc:
             logger.error("Timed out waiting for Jenkins, %s", exc)
@@ -189,8 +173,8 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         1. Remove plugins that are installed but are not allowed by plugins config value.
         2. Update Jenkins patch version if available and is within restart-time-range config value.
         """
-        container = self.unit.get_container(self.state.jenkins_service_name)
-        if not container.can_connect() or not self.is_storage_ready:
+        container = self.unit.get_container(JENKINS_SERVICE_NAME)
+        if not container.can_connect() or not self.state.is_storage_ready:
             self.unit.status = ops.WaitingStatus("Waiting for container/storage.")
             return
 
@@ -207,7 +191,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         Args:
             event: The event fired when the storage is attached.
         """
-        container = self.unit.get_container(self.state.jenkins_service_name)
+        container = self.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect():
             self.unit.status = ops.WaitingStatus("Waiting for pebble.")
             return

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -22,30 +22,30 @@ import requests
 from pydantic import HttpUrl
 
 import state
+from state import JENKINS_HOME_PATH
 
 logger = logging.getLogger(__name__)
 
 WEB_PORT = 8080
 WEB_URL = f"http://localhost:{WEB_PORT}"
 LOGIN_URL = f"{WEB_URL}/login?from=%2F"
-HOME_PATH = Path("/var/lib/jenkins")
 EXECUTABLES_PATH = Path("/srv/jenkins/")
 # Path to initial Jenkins password file
-PASSWORD_FILE_PATH = HOME_PATH / "secrets/initialAdminPassword"
+PASSWORD_FILE_PATH = JENKINS_HOME_PATH / "secrets/initialAdminPassword"
 # Path to Jenkins admin API token
-API_TOKEN_PATH = HOME_PATH / "secrets/apiToken"
+API_TOKEN_PATH = JENKINS_HOME_PATH / "secrets/apiToken"
 # Path to last executed Jenkins version file, required to override wizard installation
-LAST_EXEC_VERSION_PATH = HOME_PATH / Path("jenkins.install.InstallUtil.lastExecVersion")
+LAST_EXEC_VERSION_PATH = JENKINS_HOME_PATH / Path("jenkins.install.InstallUtil.lastExecVersion")
 # Path to Jenkins version file, required to override wizard installation
-WIZARD_VERSION_PATH = HOME_PATH / Path("jenkins.install.UpgradeWizard.state")
+WIZARD_VERSION_PATH = JENKINS_HOME_PATH / Path("jenkins.install.UpgradeWizard.state")
 # The Jenkins bootstrapping config path
-CONFIG_FILE_PATH = HOME_PATH / "config.xml"
+CONFIG_FILE_PATH = JENKINS_HOME_PATH / "config.xml"
 # The Jenkins plugins installation directory
-PLUGINS_PATH = HOME_PATH / "plugins"
+PLUGINS_PATH = JENKINS_HOME_PATH / "plugins"
 # The Jenkins logging configuration path
-LOGGING_CONFIG_PATH = HOME_PATH / "logging.properties"
+LOGGING_CONFIG_PATH = JENKINS_HOME_PATH / "logging.properties"
 # The Jenkins logging path as defined in templates/logging.properties file
-LOGGING_PATH = HOME_PATH / "jenkins.log"
+LOGGING_PATH = JENKINS_HOME_PATH / "jenkins.log"
 
 # The plugins that are required for Jenkins to work
 REQUIRED_PLUGINS = [
@@ -218,7 +218,7 @@ def calculate_env() -> Environment:
     Returns:
         The dictionary mapping of environment variables for the Jenkins service.
     """
-    return Environment(JENKINS_HOME=str(HOME_PATH))
+    return Environment(JENKINS_HOME=str(JENKINS_HOME_PATH))
 
 
 def get_version() -> str:

--- a/src/state.py
+++ b/src/state.py
@@ -11,12 +11,15 @@ import typing
 import ops
 from pydantic import BaseModel, Field, HttpUrl, ValidationError, validator
 
+import jenkins
 from timerange import InvalidTimeRangeError, Range
 
 logger = logging.getLogger(__name__)
 
 AGENT_RELATION = "agent"
 DEPRECATED_AGENT_RELATION = "agent-deprecated"
+JENKINS_SERVICE_NAME = "jenkins"
+JENKINS_HOME_STORAGE_NAME = "jenkins-home"
 
 
 class CharmStateBaseError(Exception):
@@ -214,6 +217,22 @@ class ProxyConfig(BaseModel):
         )
 
 
+def is_storage_ready(charm: ops.CharmBase) -> bool:
+    """Return whether the Jenkins home storage is mounted.
+
+    Args:
+        charm: The Jenkins k8s charm.
+
+    Returns:
+        True if storage is mounted, False otherwise.
+    """
+    container = charm.unit.get_container(JENKINS_SERVICE_NAME)
+    if not container.can_connect():
+        return False
+    mount_info: str = container.pull("/proc/mounts").read()
+    return str(jenkins.HOME_PATH) in mount_info
+
+
 @dataclasses.dataclass(frozen=True)
 class State:
     """The Jenkins k8s operator charm state.
@@ -223,10 +242,9 @@ class State:
         agent_relation_meta: Metadata of all agents from units related through agent relation.
         deprecated_agent_relation_meta: Metadata of all agents from units related through
             deprecated agent relation.
+        is_storage_ready: Whether the Jenkins home storage is mounted.
         proxy_config: Proxy configuration to access Jenkins upstream through.
         plugins: The list of allowed plugins to install.
-        jenkins_service_name: The Jenkins service name. Note that the container name is the same.
-        storage_name: The Jenkins home storage name.
     """
 
     restart_time_range: typing.Optional[Range]
@@ -236,8 +254,7 @@ class State:
     ]
     proxy_config: typing.Optional[ProxyConfig]
     plugins: typing.Optional[typing.Iterable[str]]
-    jenkins_service_name: str = "jenkins"
-    storage_name: str = "jenkins-home"
+    is_storage_ready: bool
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "State":
@@ -297,6 +314,7 @@ class State:
             restart_time_range=restart_time_range,
             agent_relation_meta=agent_relation_meta_map,
             deprecated_agent_relation_meta=deprecated_agent_meta_map,
+            is_storage_ready=is_storage_ready(charm=charm),
             plugins=plugins,
             proxy_config=proxy_config,
         )

--- a/src/state.py
+++ b/src/state.py
@@ -7,11 +7,11 @@ import functools
 import logging
 import os
 import typing
+from pathlib import Path
 
 import ops
 from pydantic import BaseModel, Field, HttpUrl, ValidationError, validator
 
-import jenkins
 from timerange import InvalidTimeRangeError, Range
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,7 @@ AGENT_RELATION = "agent"
 DEPRECATED_AGENT_RELATION = "agent-deprecated"
 JENKINS_SERVICE_NAME = "jenkins"
 JENKINS_HOME_STORAGE_NAME = "jenkins-home"
+JENKINS_HOME_PATH = Path("/var/lib/jenkins")
 
 
 class CharmStateBaseError(Exception):
@@ -217,7 +218,7 @@ class ProxyConfig(BaseModel):
         )
 
 
-def is_storage_ready(charm: ops.CharmBase) -> bool:
+def _is_storage_ready(charm: ops.CharmBase) -> bool:
     """Return whether the Jenkins home storage is mounted.
 
     Args:
@@ -230,7 +231,7 @@ def is_storage_ready(charm: ops.CharmBase) -> bool:
     if not container.can_connect():
         return False
     mount_info: str = container.pull("/proc/mounts").read()
-    return str(jenkins.HOME_PATH) in mount_info
+    return str(JENKINS_HOME_PATH) in mount_info
 
 
 @dataclasses.dataclass(frozen=True)
@@ -314,7 +315,7 @@ class State:
             restart_time_range=restart_time_range,
             agent_relation_meta=agent_relation_meta_map,
             deprecated_agent_relation_meta=deprecated_agent_meta_map,
-            is_storage_ready=is_storage_ready(charm=charm),
+            is_storage_ready=_is_storage_ready(charm=charm),
             plugins=plugins,
             proxy_config=proxy_config,
         )

--- a/src/state.py
+++ b/src/state.py
@@ -226,6 +226,7 @@ class State:
         proxy_config: Proxy configuration to access Jenkins upstream through.
         plugins: The list of allowed plugins to install.
         jenkins_service_name: The Jenkins service name. Note that the container name is the same.
+        storage_name: The Jenkins home storage name.
     """
 
     restart_time_range: typing.Optional[Range]
@@ -236,6 +237,7 @@ class State:
     proxy_config: typing.Optional[ProxyConfig]
     plugins: typing.Optional[typing.Iterable[str]]
     jenkins_service_name: str = "jenkins"
+    storage_name: str = "jenkins-home"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "State":

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -169,6 +169,7 @@ def container_fixture(
     proxy_config: state.ProxyConfig,
 ) -> Container:
     """Harness Jenkins workload container that acts as a Jenkins container."""
+    harness.add_storage(state.State.storage_name, count=1, attach=True)
     jenkins_root = harness.get_filesystem_root("jenkins")
     password_file_path = combine_root_paths(jenkins_root, jenkins.PASSWORD_FILE_PATH)
     password_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -171,6 +171,9 @@ def container_fixture(
     """Harness Jenkins workload container that acts as a Jenkins container."""
     harness.add_storage(state.State.storage_name, count=1, attach=True)
     jenkins_root = harness.get_filesystem_root("jenkins")
+    storage_mount_proc_path = combine_root_paths(jenkins_root, Path("/proc/mounts"))
+    storage_mount_proc_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_mount_proc_path.write_text(str(jenkins.HOME_PATH), "utf-8")
     password_file_path = combine_root_paths(jenkins_root, jenkins.PASSWORD_FILE_PATH)
     password_file_path.parent.mkdir(parents=True, exist_ok=True)
     password_file_path.write_text(admin_credentials.password_or_token, encoding="utf-8")
@@ -250,7 +253,7 @@ def container_fixture(
 
 @pytest.fixture(scope="function", name="harness_container")
 def harness_container_fixture(harness: Harness, container: Container) -> HarnessWithContainer:
-    """Named tuple containing Harness with container."""
+    """Named tuple containing Harness with container with container ready and fs mounted."""
     return HarnessWithContainer(harness=harness, container=container)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -169,7 +169,7 @@ def container_fixture(
     proxy_config: state.ProxyConfig,
 ) -> Container:
     """Harness Jenkins workload container that acts as a Jenkins container."""
-    harness.add_storage(state.State.storage_name, count=1, attach=True)
+    harness.add_storage(state.JENKINS_HOME_STORAGE_NAME, count=1, attach=True)
     jenkins_root = harness.get_filesystem_root("jenkins")
     storage_mount_proc_path = combine_root_paths(jenkins_root, Path("/proc/mounts"))
     storage_mount_proc_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -173,7 +173,7 @@ def container_fixture(
     jenkins_root = harness.get_filesystem_root("jenkins")
     storage_mount_proc_path = combine_root_paths(jenkins_root, Path("/proc/mounts"))
     storage_mount_proc_path.parent.mkdir(parents=True, exist_ok=True)
-    storage_mount_proc_path.write_text(str(jenkins.HOME_PATH), "utf-8")
+    storage_mount_proc_path.write_text(str(state.JENKINS_HOME_PATH), "utf-8")
     password_file_path = combine_root_paths(jenkins_root, jenkins.PASSWORD_FILE_PATH)
     password_file_path.parent.mkdir(parents=True, exist_ok=True)
     password_file_path.write_text(admin_credentials.password_or_token, encoding="utf-8")

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -10,6 +10,7 @@ import requests
 ACTIVE_STATUS_NAME = "active"
 BLOCKED_STATUS_NAME = "blocked"
 MAINTENANCE_STATUS_NAME = "maintenance"
+WAITING_STATUS_NAME = "waiting"
 
 
 # There aren't enough public methods with this patch class.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,33 +42,6 @@ def test___init___invailid_config(
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
-def test_is_storage_ready_no_container(harness: Harness):
-    """
-    arrange: given Jenkins charm with container not yet ready.
-    act: when is_storage_ready is called.
-    assert: Falsy value is returned.
-    """
-    harness.begin()
-
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-
-    assert not jenkins_charm.is_storage_ready
-
-
-def test_is_storage_ready(harness_container: HarnessWithContainer):
-    """
-    arrange: given Jenkins charm with container ready and storage mounted.
-    act: when is_storage_ready is called.
-    assert: Truthy value is returned.
-    """
-    harness = harness_container.harness
-    harness.begin()
-
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-
-    assert jenkins_charm.is_storage_ready
-
-
 @pytest.mark.parametrize(
     "event_handler",
     [

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ import state
 import timerange
 from charm import JenkinsK8sOperatorCharm
 
-from .helpers import ACTIVE_STATUS_NAME, BLOCKED_STATUS_NAME
+from .helpers import ACTIVE_STATUS_NAME, BLOCKED_STATUS_NAME, WAITING_STATUS_NAME
 from .types_ import Harness, HarnessWithContainer
 
 
@@ -42,24 +42,60 @@ def test___init___invailid_config(
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
-def test__on_jenkins_pebble_ready_no_container(harness_container: HarnessWithContainer):
+@pytest.mark.parametrize(
+    "event_handler",
+    [
+        pytest.param("_on_jenkins_home_storage_attached"),
+        pytest.param("_on_jenkins_pebble_ready"),
+        pytest.param("_on_update_status"),
+    ],
+)
+def test_workload_not_ready(harness: Harness, event_handler: str):
     """
-    arrange: given a pebble ready event with container unable to connect.
-    act: when the Jenkins pebble ready event is fired.
-    assert: the event should be deferred.
+    arrange: given a charm with no container ready.
+    act: when an event hook is fired.
+    assert: the charm falls into waiting status.
     """
-    harness_container.harness.begin()
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
-    mock_event = unittest.mock.MagicMock(spec=ops.PebbleReadyEvent)
-    mock_event.workload = None
+    harness.begin()
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    handler_func = getattr(jenkins_charm, event_handler)
+    mock_event = unittest.mock.MagicMock(spec=ops.WorkloadEvent)
+    mock_event.workload = unittest.mock.MagicMock(spec=ops.model.Container)
+    mock_event.workload.can_connect.return_value = False
 
-    jenkins_charm._on_jenkins_pebble_ready(mock_event)
+    handler_func(mock_event)
 
-    mock_event.defer.assert_called()
+    assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
+
+
+@pytest.mark.parametrize(
+    "event_handler",
+    [
+        pytest.param("_on_jenkins_home_storage_attached"),
+        pytest.param("_on_jenkins_pebble_ready"),
+        pytest.param("_on_update_status"),
+    ],
+)
+def test_storage_not_ready(harness: Harness, event_handler: str):
+    """
+    arrange: given a charm with no storage ready.
+    act: when an event hook is fired.
+    assert: the charm falls into waiting status.
+    """
+    harness.begin()
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    handler_func = getattr(jenkins_charm, event_handler)
+    mock_event = unittest.mock.MagicMock(spec=ops.WorkloadEvent)
+    mock_event.workload = unittest.mock.MagicMock(spec=ops.model.Container)
+    mock_event.workload.can_connect.return_value = True
+
+    handler_func(mock_event)
+
+    assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
 
 
 def test__on_jenkins_pebble_ready_error(
-    harness_container: HarnessWithContainer,
+    harness: Harness,
     mocked_get_request: typing.Callable[[str, int, typing.Any, typing.Any], requests.Response],
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -76,15 +112,18 @@ def test__on_jenkins_pebble_ready_error(
         unittest.mock.MagicMock(side_effect=jenkins.JenkinsBootstrapError()),
     )
     monkeypatch.setattr(requests, "get", functools.partial(mocked_get_request, status_code=200))
+    harness.add_storage(state.State.storage_name, count=1, attach=True)
+    harness.set_can_connect(state.State.jenkins_service_name, True)
+    harness.begin()
 
-    harness_container.harness.begin_with_initial_hooks()
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    jenkins_charm._on_jenkins_pebble_ready(unittest.mock.MagicMock(spec=ops.PebbleReadyEvent))
 
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
 def test__on_jenkins_pebble_ready_get_version_error(
-    harness_container: HarnessWithContainer,
+    harness: Harness,
     mocked_get_request: typing.Callable[[str, int, typing.Any, typing.Any], requests.Response],
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -100,26 +139,27 @@ def test__on_jenkins_pebble_ready_get_version_error(
     monkeypatch.setattr(jenkins.wait_ready, "__defaults__", (1, 1))
     monkeypatch.setattr(jenkins, "bootstrap", lambda *_args: None)
     monkeypatch.setattr(requests, "get", functools.partial(mocked_get_request, status_code=200))
+    harness.add_storage(state.State.storage_name, count=1, attach=True)
+    harness.set_can_connect(state.State.jenkins_service_name, True)
+    harness.begin()
 
-    harness_container.harness.begin_with_initial_hooks()
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    jenkins_charm._on_jenkins_pebble_ready(unittest.mock.MagicMock(spec=ops.PebbleReadyEvent))
 
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
 @pytest.mark.parametrize(
-    "status_code,expected_status",
+    "exception,expected_status",
     [
-        pytest.param(503, ops.BlockedStatus, id="jenkins not ready"),
-        pytest.param(200, ops.ActiveStatus, id="jenkins ready"),
+        pytest.param(TimeoutError, ops.BlockedStatus, id="jenkins not ready"),
+        pytest.param(None, ops.ActiveStatus, id="jenkins ready"),
     ],
 )
-# there are too many dependent fixtures that cannot be merged.
-def test__on_jenkins_pebble_ready(  # pylint: disable=too-many-arguments
-    harness_container: HarnessWithContainer,
-    mocked_get_request: typing.Callable[[str, int, typing.Any, typing.Any], requests.Response],
+def test__on_jenkins_pebble_ready(
+    harness: Harness,
     monkeypatch: pytest.MonkeyPatch,
-    status_code: int,
+    exception: Exception | None,
     expected_status: ops.StatusBase,
 ):
     """
@@ -131,15 +171,19 @@ def test__on_jenkins_pebble_ready(  # pylint: disable=too-many-arguments
     # proxy environment is picked up, making the test fail.
     monkeypatch.setattr(state.os, "environ", {})
     # speed up waiting by changing default argument values
-    monkeypatch.setattr(jenkins.wait_ready, "__defaults__", (1, 1))
-    monkeypatch.setattr(jenkins, "_setup_user_token", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        requests, "get", functools.partial(mocked_get_request, status_code=status_code)
+        jenkins, "wait_ready", unittest.mock.MagicMock(side_effect=[None, exception])
     )
+    monkeypatch.setattr(jenkins, "bootstrap", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(jenkins, "get_version", lambda *_args, **_kwargs: "1")
+    harness.add_storage(state.State.storage_name, count=1, attach=True)
+    harness.set_can_connect(state.State.jenkins_service_name, True)
+    harness.begin()
 
-    harness_container.harness.begin_with_initial_hooks()
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    jenkins_charm._on_jenkins_pebble_ready(unittest.mock.MagicMock(spec=ops.PebbleReadyEvent))
 
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
     assert (
         jenkins_charm.unit.status.name == expected_status.name
     ), f"unit should be in {expected_status}"
@@ -206,30 +250,6 @@ def test__remove_unlisted_plugins(
 
     assert returned_status.name == ACTIVE_STATUS_NAME
     assert returned_status.message == ""
-
-
-def test__on_update_status_no_container(
-    harness_container: HarnessWithContainer, monkeypatch: pytest.MonkeyPatch
-):
-    """
-    arrange: given a charm with container not yet ready to connect.
-    act: when _on_update_status is called.
-    assert: no further functions are called.
-    """
-    mock_remove_unlisted_plugins_func = unittest.mock.MagicMock(
-        spec=JenkinsK8sOperatorCharm._remove_unlisted_plugins
-    )
-    harness, container = harness_container.harness, harness_container.container
-    harness.set_can_connect(container, False)
-    harness.begin()
-
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
-    monkeypatch.setattr(
-        jenkins_charm, "_remove_unlisted_plugins", mock_remove_unlisted_plugins_func
-    )
-    jenkins_charm._on_update_status(unittest.mock.MagicMock(spec=ops.UpdateStatusEvent))
-
-    mock_remove_unlisted_plugins_func.assert_not_called()
 
 
 def test__on_update_status_not_in_time_range(

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -186,7 +186,7 @@ def test_calculate_env():
     """
     env = jenkins.calculate_env()
 
-    assert env == {"JENKINS_HOME": str(jenkins.HOME_PATH)}
+    assert env == {"JENKINS_HOME": str(state.JENKINS_HOME_PATH)}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -7,8 +7,39 @@ import unittest.mock
 
 import ops
 import pytest
+from ops.testing import Harness
 
 import state
+from charm import JenkinsK8sOperatorCharm
+
+from .types_ import HarnessWithContainer
+
+
+def test_is_storage_ready_no_container(harness: Harness):
+    """
+    arrange: given Jenkins charm with container not yet ready.
+    act: when is_storage_ready is called.
+    assert: Falsy value is returned.
+    """
+    harness.begin()
+
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+
+    assert not jenkins_charm.state.is_storage_ready
+
+
+def test_is_storage_ready(harness_container: HarnessWithContainer):
+    """
+    arrange: given Jenkins charm with container ready and storage mounted.
+    act: when is_storage_ready is called.
+    assert: Truthy value is returned.
+    """
+    harness = harness_container.harness
+    harness.begin()
+
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+
+    assert jenkins_charm.state.is_storage_ready
 
 
 def test_state_invalid_time_config():


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Prevent any service events (pebble_ready, storage_ready, update_status, actions) from continuing before all preconditions (container ready & storage mounted) are ready.

### Rationale

Prevent unstable behavior of Jenkins when the service starts before the storage has been properly mounted.

### Juju Events Changes

N/A

### Module Changes

`charm.py` - event handlers have storage attached check.
`actions.py` - action event handlers have storage attached check.
`agent.py` - agent relation handlers have storage attached check.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
