### PR TITLE
Fix/agent relation

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -62,6 +62,8 @@ class Observer(ops.Object):
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Service not yet ready. Deferring.")
+            event.defer()
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -101,6 +103,8 @@ class Observer(ops.Object):
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Service not yet ready. Deferring.")
+            event.defer()
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -144,6 +148,8 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Relation departed before service ready.")
+            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -171,6 +177,7 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Relation departed before service ready.")
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -149,7 +149,6 @@ class Observer(ops.Object):
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
             logger.warning("Relation departed before service ready.")
-            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Defer relation joined events that cannot be handled before service is ready.

### Rationale

Events are fired before the service is ready and it is not deferred - the relation does not progress.

### Juju Events Changes

None.

### Module Changes

Non.e

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
