### PR TITLE
chore: comment on deferred events.

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -62,6 +62,8 @@ class Observer(ops.Object):
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Service not yet ready. Deferring.")
+            event.defer()
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -101,6 +103,8 @@ class Observer(ops.Object):
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Service not yet ready. Deferring.")
+            event.defer()
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -144,6 +148,8 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Relation departed before service ready.")
+            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the
@@ -171,6 +177,7 @@ class Observer(ops.Object):
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
+            logger.warning("Relation departed before service ready.")
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -149,7 +149,6 @@ class Observer(ops.Object):
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
             logger.warning("Relation departed before service ready.")
-            event.defer()
             return
 
         # The relation data is removed before this particular hook runs, making the name set by the

--- a/src/agent.py
+++ b/src/agent.py
@@ -63,7 +63,7 @@ class Observer(ops.Object):
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
             logger.warning("Service not yet ready. Deferring.")
-            event.defer()
+            event.defer()  # The event needs to be handled after Jenkins has started(pebble ready).
             return
         # The relation is joined, it cannot be None, hence the type casting.
         deprecated_agent_relation_meta = typing.cast(
@@ -73,6 +73,7 @@ class Observer(ops.Object):
         agent_meta = deprecated_agent_relation_meta[typing.cast(ops.Unit, event.unit).name]
         if not agent_meta:
             logger.warning("Relation data not ready yet. Deferring.")
+            # The event needs to be retried until the agents have set it's side of relation data.
             event.defer()
             return
 
@@ -104,7 +105,7 @@ class Observer(ops.Object):
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect() or not self.state.is_storage_ready:
             logger.warning("Service not yet ready. Deferring.")
-            event.defer()
+            event.defer()  # The event needs to be handled after Jenkins has started(pebble ready).
             return
         # The relation is joined, it cannot be None, hence the type casting.
         agent_relation_meta = typing.cast(
@@ -114,6 +115,7 @@ class Observer(ops.Object):
         agent_meta = agent_relation_meta[typing.cast(ops.Unit, event.unit).name]
         if not agent_meta:
             logger.warning("Relation data not ready yet. Deferring.")
+            # The event needs to be retried until the agents have set it's side of relation data.
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -109,7 +109,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         container = self.unit.get_container(JENKINS_SERVICE_NAME)
         if not container or not container.can_connect() or not self.state.is_storage_ready:
             self.unit.status = ops.WaitingStatus("Waiting for container/storage.")
-            event.defer()
+            event.defer()  # Jenkins installation should be retried until preconditions are met.
             return
 
         self.unit.status = ops.MaintenanceStatus("Installing Jenkins.")


### PR DESCRIPTION
Applicable spec: N/A.

### Overview

Adds comments justifying the deferred events.

### Rationale

Defer is usually not recommended to use. However, since every handler surgically does an operation that doesn't globally handle the service restarts/logic, defer must be used in many cases. The comments help reason about the use of defers.

### Juju Events Changes

None.

### Module Changes

None(comments added).

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
