### PR TITLE
feat: open port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -144,6 +144,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             return
 
         self.unit.set_workload_version(version)
+        self.unit.set_ports(jenkins.WEB_PORT)
         self.unit.status = ops.ActiveStatus()
 
     def _remove_unlisted_plugins(self, container: ops.Container) -> ops.StatusBase:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -429,3 +429,11 @@ def mock_charm_fixture():
     mock_charm = unittest.mock.MagicMock(spec=CharmBase)
     mock_charm.app.planned_units.return_value = 1
     return mock_charm
+
+
+@pytest.fixture(scope="function", name="patch_os_environ")
+def patch_os_environ_fixture(monkeypatch: pytest.MonkeyPatch):
+    """Monkeypatch os.environ variable to enable testing in self-hosted runners."""
+    # monkeypatch environment variables because the test is running in self-hosted runners and juju
+    # proxy environment is picked up, making the test fail.
+    monkeypatch.setattr(state.os, "environ", {})

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -431,7 +431,7 @@ def mock_charm_fixture():
     return mock_charm
 
 
-@pytest.fixture(scope="function", name="patch_os_environ")
+@pytest.fixture(scope="function", name="patch_os_environ", autouse=True)
 def patch_os_environ_fixture(monkeypatch: pytest.MonkeyPatch):
     """Monkeypatch os.environ variable to enable testing in self-hosted runners."""
     # monkeypatch environment variables because the test is running in self-hosted runners and juju

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -179,7 +179,7 @@ def test__on_jenkins_pebble_ready(
     """
     arrange: given a mocked jenkins client and a patched requests instance.
     act: when the Jenkins pebble ready event is fired.
-    assert: the unit status should show expected status.
+    assert: the unit status should show expected status and the jenkins port should be open.
     """
     harness = harness_container.harness
     monkeypatch.setattr(jenkins, "wait_ready", unittest.mock.MagicMock(return_value=None))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,7 +16,6 @@ import pytest
 import requests
 
 import jenkins
-import state
 import timerange
 from charm import JenkinsK8sOperatorCharm
 
@@ -147,6 +146,7 @@ def test__on_jenkins_pebble_ready_get_version_error(
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
+@pytest.mark.usefixtures("patch_os_environ")
 def test__on_jenkins_pebble_jenkins_not_ready(
     harness_container: HarnessWithContainer, monkeypatch: pytest.MonkeyPatch
 ):
@@ -156,10 +156,6 @@ def test__on_jenkins_pebble_jenkins_not_ready(
     assert: Jenkins falls into BlockedStatus.
     """
     harness = harness_container.harness
-    # monkeypatch environment variables because the test is running in self-hosted runners and juju
-    # proxy environment is picked up, making the test fail.
-    monkeypatch.setattr(state.os, "environ", {})
-    # speed up waiting by changing default argument values
     monkeypatch.setattr(
         jenkins, "wait_ready", unittest.mock.MagicMock(side_effect=[None, TimeoutError])
     )
@@ -176,6 +172,7 @@ def test__on_jenkins_pebble_jenkins_not_ready(
     ), f"unit should be in {BLOCKED_STATUS_NAME}"
 
 
+@pytest.mark.usefixtures("patch_os_environ")
 def test__on_jenkins_pebble_ready(
     harness_container: HarnessWithContainer, monkeypatch: pytest.MonkeyPatch
 ):
@@ -185,10 +182,6 @@ def test__on_jenkins_pebble_ready(
     assert: the unit status should show expected status.
     """
     harness = harness_container.harness
-    # monkeypatch environment variables because the test is running in self-hosted runners and juju
-    # proxy environment is picked up, making the test fail.
-    monkeypatch.setattr(state.os, "environ", {})
-    # speed up waiting by changing default argument values
     monkeypatch.setattr(jenkins, "wait_ready", unittest.mock.MagicMock(return_value=None))
     monkeypatch.setattr(jenkins, "bootstrap", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(jenkins, "get_version", lambda *_args, **_kwargs: "1")

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,7 @@ description = Run integration tests
 deps =
     pytest
     juju>=3,<4
+    macaroonbakery==1.3.2 # temporary bug with libjuju
     ops
     pytest-operator
     pytest-asyncio


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add an [open port to k8s service](https://juju.is/docs/sdk/open-a-kubernetes-port-in-your-charm#heading--add-a-kubernetes-service-port-to-your-charm) which is a good information for SREs when deploying the charm.

### Rationale

Helps annotate the k8s service with port definitions.

### Juju Events Changes

The pebble ready event sets open port when charm is successfully initialized.

### Module Changes

`charm.py`

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
