### PR TITLE
chore: bump jenkins-k8s LTS version

### DIFF
--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -40,7 +40,7 @@ parts:
       - default-jre-headless
       - git
     build-environment:
-      - JENKINS_VERSION: 2.414.1
+      - JENKINS_VERSION: 2.426.1
       - JENKINS_PLUGIN_MANAGER_VERSION: 2.12.13
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/{srv/jenkins/,etc/default/jenkins/}


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Bump to the latest Jenkins LTS version to mitigate CVEs.

### Rationale

To mitigate CVEs.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
