### PR TITLE
Use self-hosted runner for integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,3 +17,5 @@ jobs:
         chmod +x tests/integration/pre_run_script.sh
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.1/stable
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,8 @@ deps =
     ops
     pytest-operator
     pytest-asyncio
+    # Type error problem with newer version of macaroonbakery
+    macaroonbakery==1.3.2
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}integration/requirements.txt
 commands =


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use `edge` self-hosted runner for integration test

### Rationale

- Reduce load on GitHub-provided runner on the organisation.
- Test out the edge revision of github-runner charm on this repo.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
