### PR TITLE
fix: integration test & workflow

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -8,8 +8,5 @@ on:
 
 jobs:
   comment-on-pr:
-    permissions:
-      packages: read
-      pull_requests: write
-    uses: canonical/operator-workflows/.github/workflows/comment.yaml@fix/permissions
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
     secrets: inherit

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -8,5 +8,8 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    permissions:
+      packages: read
+      pull_requests: write
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@fix/permissions
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,4 +21,4 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.1/stable
       self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner-label: "xlarge"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,9 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
     with:
       channel: 1.28-strict/stable
       extra-arguments: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,9 +7,6 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
-    permissions:
-      contents: read
-      packages: write
     with:
       channel: 1.28-strict/stable
       extra-arguments: |

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -22,14 +22,12 @@ logger = logging.getLogger(__name__)
 
 
 async def install_plugins(
-    unit: Unit,
     unit_web_client: UnitWebClient,
     plugins: typing.Iterable[str],
 ) -> None:
     """Install plugins to Jenkins unit.
 
     Args:
-        unit: The Jenkins unit to install plugins to.
         unit_web_client: The wrapper around unit, web_address and jenkins_client.
         plugins: Desired plugins to install.
     """

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -11,7 +11,6 @@ import pytest
 from juju.action import Action
 from juju.application import Application
 from juju.unit import Unit
-from pytest_operator.plugin import OpsTest
 
 from .helpers import gen_test_job_xml, install_plugins
 from .substrings import assert_substrings_not_in_string
@@ -39,7 +38,6 @@ async def test_jenkins_update_ui_disabled(
 
 @pytest.mark.usefixtures("app_with_restart_time_range", "libfaketime_unit")
 async def test_jenkins_automatic_update_out_of_range(
-    ops_test: OpsTest,
     libfaketime_env: typing.Iterable[str],
     update_status_env: typing.Iterable[str],
     unit_web_client: UnitWebClient,
@@ -50,7 +48,7 @@ async def test_jenkins_automatic_update_out_of_range(
     assert: the maintenance (plugins removal) does not take place.
     """
     extra_plugin = "oic-auth"
-    await install_plugins(ops_test, unit_web_client, (extra_plugin,))
+    await install_plugins(unit_web_client, (extra_plugin,))
     action: Action = await unit_web_client.unit.run(
         f"-- {' '.join(libfaketime_env)} {' '.join(update_status_env)} ./dispatch"
     )

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -50,7 +50,7 @@ async def test_jenkins_automatic_update_out_of_range(
     assert: the maintenance (plugins removal) does not take place.
     """
     extra_plugin = "oic-auth"
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, (extra_plugin,))
+    await install_plugins(ops_test, unit_web_client, (extra_plugin,))
     action: Action = await unit_web_client.unit.run(
         f"-- {' '.join(libfaketime_env)} {' '.join(update_status_env)} ./dispatch"
     )

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -29,7 +29,7 @@ async def test_jenkins_plugins_config(
     act: when update_status_hook is fired.
     assert: the plugin is uninstalled and the system message is set on Jenkins.
     """
-    await install_plugins(ops_test, unit_web_client, INSTALLED_PLUGINS)
+    await install_plugins(unit_web_client, INSTALLED_PLUGINS)
 
     ret_code, _, stderr = await ops_test.juju(
         "exec",
@@ -52,13 +52,13 @@ async def test_jenkins_plugins_config(
 
 
 @pytest.mark.usefixtures("k8s_agent_related_app")
-async def test_git_plugin_k8s_agent(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_git_plugin_k8s_agent(unit_web_client: UnitWebClient):
     """
     arrange: given a jenkins charm with git plugin installed.
     act: when a job is dispatched with a git workflow.
     assert: job completes successfully.
     """
-    await install_plugins(ops_test, unit_web_client, INSTALLED_PLUGINS)
+    await install_plugins(unit_web_client, INSTALLED_PLUGINS)
 
     job_name = "git-plugin-test-k8s"
     unit_web_client.client.create_job(job_name, gen_git_test_job_xml("k8s"))
@@ -78,7 +78,6 @@ async def test_git_plugin_k8s_agent(ops_test: OpsTest, unit_web_client: UnitWebC
 
 @pytest.mark.usefixtures("app_with_allowed_plugins")
 async def test_ldap_plugin(
-    ops_test: OpsTest,
     unit_web_client: UnitWebClient,
     ldap_server_ip: str,
     ldap_settings: LDAPSettings,
@@ -88,7 +87,7 @@ async def test_ldap_plugin(
     act: when ldap plugin is configured and the user is queried.
     assert: the user is authenticated successfully.
     """
-    await install_plugins(ops_test, unit_web_client, ("ldap",))
+    await install_plugins(unit_web_client, ("ldap",))
 
     # This is same as: Manage Jenkins > Configure Global Security > Authentication >
     # Security Realm > LDAP > Test LDAP Settings.
@@ -146,15 +145,13 @@ async def test_ldap_plugin(
 
 
 @pytest.mark.usefixtures("app_with_allowed_plugins")
-async def test_matrix_combinations_parameter_plugin(
-    ops_test: OpsTest, unit_web_client: UnitWebClient
-):
+async def test_matrix_combinations_parameter_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a jenkins server with matrix-combinations-parameter plugin installed.
     act: when a multi-configuration job is created.
     assert: a matrix based test is created.
     """
-    await install_plugins(ops_test, unit_web_client, ("matrix-combinations-parameter",))
+    await install_plugins(unit_web_client, ("matrix-combinations-parameter",))
     matrix_project_plugin: jenkinsapi.plugin.Plugin = unit_web_client.client.plugins[
         "matrix-project"
     ]
@@ -190,7 +187,7 @@ async def test_postbuildscript_plugin(
     act: when a postbuildscript job that writes a file to a /tmp folder is dispatched.
     assert: the file is written on the /tmp folder of the job host.
     """
-    await install_plugins(ops_test, unit_web_client, ("postbuildscript",))
+    await install_plugins(unit_web_client, ("postbuildscript",))
     postbuildscript_plugin: jenkinsapi.plugin.Plugin = unit_web_client.client.plugins[
         "postbuildscript"
     ]
@@ -215,13 +212,13 @@ async def test_postbuildscript_plugin(
     assert stdout == test_output
 
 
-async def test_ssh_agent_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_ssh_agent_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given jenkins charm with ssh_agent plugin installed.
     act: when a job is being configured.
     assert: ssh-agent configuration is visible.
     """
-    await install_plugins(ops_test, unit_web_client, ("ssh-agent",))
+    await install_plugins(unit_web_client, ("ssh-agent",))
     unit_web_client.client.create_job("ssh_agent_test", gen_test_job_xml("k8s"))
 
     res = unit_web_client.client.requester.get_url(
@@ -232,13 +229,13 @@ async def test_ssh_agent_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     assert "SSH Agent" in config_page, f"SSH agent configuration not found. {config_page}"
 
 
-async def test_blueocean_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_blueocean_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a jenkins charm with blueocean plugin installed.
     act: when blueocean frontend url is accessed.
     assert: 200 response is returned.
     """
-    await install_plugins(ops_test, unit_web_client, ("blueocean",))
+    await install_plugins(unit_web_client, ("blueocean",))
 
     res = unit_web_client.client.requester.get_url(
         f"{unit_web_client.web}/blue/organizations/jenkins/"
@@ -255,7 +252,7 @@ async def test_thinbackup_plugin(ops_test: OpsTest, unit_web_client: UnitWebClie
     act: when a backup action is run.
     assert: the backup is made on a configured directory.
     """
-    await install_plugins(ops_test, unit_web_client, ("thinBackup",))
+    await install_plugins(unit_web_client, ("thinBackup",))
     backup_path = "/srv/jenkins/backup/"
     res = unit_web_client.client.requester.post_url(
         f"{unit_web_client.web}/manage/thinBackup/saveSettings",
@@ -283,13 +280,13 @@ async def test_thinbackup_plugin(ops_test: OpsTest, unit_web_client: UnitWebClie
     assert "FULL" in stdout, "The backup folder of format FULL-<backup-date> not found."
 
 
-async def test_bzr_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_bzr_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a Jenkins charm with bazaar plugin installed.
     act: when a job configuration page is accessed.
     assert: bazaar plugin option exists.
     """
-    await install_plugins(ops_test, unit_web_client, ("bazaar",))
+    await install_plugins(unit_web_client, ("bazaar",))
     unit_web_client.client.create_job("bzr_plugin_test", gen_test_job_xml("k8s"))
 
     res = unit_web_client.client.requester.get_url(
@@ -301,13 +298,13 @@ async def test_bzr_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
 
 
 @pytest.mark.usefixtures("k8s_agent_related_app")
-async def test_rebuilder_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_rebuilder_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a Jenkins charm with rebuilder plugin installed.
     act: when a job is built and a rebuild is triggered.
     assert: last job is rebuilt.
     """
-    await install_plugins(ops_test, unit_web_client, ("rebuild",))
+    await install_plugins(unit_web_client, ("rebuild",))
 
     job_name = "rebuild_test"
     job = unit_web_client.client.create_job(job_name, gen_test_job_xml("k8s"))
@@ -321,13 +318,13 @@ async def test_rebuilder_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     assert job.get_last_buildnumber() == 2, "Rebuild not triggered."
 
 
-async def test_openid_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
+async def test_openid_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a Jenkins charm with openid plugin installed.
     act: when an openid endpoint is validated using the plugin.
     assert: the response returns a 200 status code.
     """
-    await install_plugins(ops_test, unit_web_client, ("openid",))
+    await install_plugins(unit_web_client, ("openid",))
 
     res = unit_web_client.client.requester.post_url(
         f"{unit_web_client.web}/manage/descriptorByName/hudson.plugins.openid."
@@ -339,7 +336,6 @@ async def test_openid_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
 
 
 async def test_openid_connect_plugin(
-    ops_test: OpsTest,
     unit_web_client: UnitWebClient,
     keycloak_oidc_meta: KeycloakOIDCMetadata,
     keycloak_ip: str,
@@ -353,7 +349,7 @@ async def test_openid_connect_plugin(
         1. a redirection to Keycloak SSO is made.
         2. native Jenkins login ui is loaded.
     """
-    await install_plugins(ops_test, unit_web_client, ("oic-auth",))
+    await install_plugins(unit_web_client, ("oic-auth",))
 
     # 1. when jenkins security realm is configured with oidc server and login page is requested.
     payload: dict = {

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -29,9 +29,7 @@ async def test_jenkins_plugins_config(
     act: when update_status_hook is fired.
     assert: the plugin is uninstalled and the system message is set on Jenkins.
     """
-    await install_plugins(
-        ops_test, unit_web_client.unit, unit_web_client.client, INSTALLED_PLUGINS
-    )
+    await install_plugins(ops_test, unit_web_client, INSTALLED_PLUGINS)
 
     ret_code, _, stderr = await ops_test.juju(
         "exec",
@@ -60,9 +58,7 @@ async def test_git_plugin_k8s_agent(ops_test: OpsTest, unit_web_client: UnitWebC
     act: when a job is dispatched with a git workflow.
     assert: job completes successfully.
     """
-    await install_plugins(
-        ops_test, unit_web_client.unit, unit_web_client.client, INSTALLED_PLUGINS
-    )
+    await install_plugins(ops_test, unit_web_client, INSTALLED_PLUGINS)
 
     job_name = "git-plugin-test-k8s"
     unit_web_client.client.create_job(job_name, gen_git_test_job_xml("k8s"))
@@ -92,7 +88,7 @@ async def test_ldap_plugin(
     act: when ldap plugin is configured and the user is queried.
     assert: the user is authenticated successfully.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("ldap",))
+    await install_plugins(ops_test, unit_web_client, ("ldap",))
 
     # This is same as: Manage Jenkins > Configure Global Security > Authentication >
     # Security Realm > LDAP > Test LDAP Settings.
@@ -158,9 +154,7 @@ async def test_matrix_combinations_parameter_plugin(
     act: when a multi-configuration job is created.
     assert: a matrix based test is created.
     """
-    await install_plugins(
-        ops_test, unit_web_client.unit, unit_web_client.client, ("matrix-combinations-parameter",)
-    )
+    await install_plugins(ops_test, unit_web_client, ("matrix-combinations-parameter",))
     matrix_project_plugin: jenkinsapi.plugin.Plugin = unit_web_client.client.plugins[
         "matrix-project"
     ]
@@ -196,9 +190,7 @@ async def test_postbuildscript_plugin(
     act: when a postbuildscript job that writes a file to a /tmp folder is dispatched.
     assert: the file is written on the /tmp folder of the job host.
     """
-    await install_plugins(
-        ops_test, unit_web_client.unit, unit_web_client.client, ("postbuildscript",)
-    )
+    await install_plugins(ops_test, unit_web_client, ("postbuildscript",))
     postbuildscript_plugin: jenkinsapi.plugin.Plugin = unit_web_client.client.plugins[
         "postbuildscript"
     ]
@@ -229,7 +221,7 @@ async def test_ssh_agent_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     act: when a job is being configured.
     assert: ssh-agent configuration is visible.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("ssh-agent",))
+    await install_plugins(ops_test, unit_web_client, ("ssh-agent",))
     unit_web_client.client.create_job("ssh_agent_test", gen_test_job_xml("k8s"))
 
     res = unit_web_client.client.requester.get_url(
@@ -246,7 +238,7 @@ async def test_blueocean_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     act: when blueocean frontend url is accessed.
     assert: 200 response is returned.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("blueocean",))
+    await install_plugins(ops_test, unit_web_client, ("blueocean",))
 
     res = unit_web_client.client.requester.get_url(
         f"{unit_web_client.web}/blue/organizations/jenkins/"
@@ -263,7 +255,7 @@ async def test_thinbackup_plugin(ops_test: OpsTest, unit_web_client: UnitWebClie
     act: when a backup action is run.
     assert: the backup is made on a configured directory.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("thinBackup",))
+    await install_plugins(ops_test, unit_web_client, ("thinBackup",))
     backup_path = "/srv/jenkins/backup/"
     res = unit_web_client.client.requester.post_url(
         f"{unit_web_client.web}/manage/thinBackup/saveSettings",
@@ -297,7 +289,7 @@ async def test_bzr_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
     act: when a job configuration page is accessed.
     assert: bazaar plugin option exists.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("bazaar",))
+    await install_plugins(ops_test, unit_web_client, ("bazaar",))
     unit_web_client.client.create_job("bzr_plugin_test", gen_test_job_xml("k8s"))
 
     res = unit_web_client.client.requester.get_url(
@@ -315,7 +307,7 @@ async def test_rebuilder_plugin(ops_test: OpsTest, unit_web_client: UnitWebClien
     act: when a job is built and a rebuild is triggered.
     assert: last job is rebuilt.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("rebuild",))
+    await install_plugins(ops_test, unit_web_client, ("rebuild",))
 
     job_name = "rebuild_test"
     job = unit_web_client.client.create_job(job_name, gen_test_job_xml("k8s"))
@@ -335,7 +327,7 @@ async def test_openid_plugin(ops_test: OpsTest, unit_web_client: UnitWebClient):
     act: when an openid endpoint is validated using the plugin.
     assert: the response returns a 200 status code.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("openid",))
+    await install_plugins(ops_test, unit_web_client, ("openid",))
 
     res = unit_web_client.client.requester.post_url(
         f"{unit_web_client.web}/manage/descriptorByName/hudson.plugins.openid."
@@ -361,7 +353,7 @@ async def test_openid_connect_plugin(
         1. a redirection to Keycloak SSO is made.
         2. native Jenkins login ui is loaded.
     """
-    await install_plugins(ops_test, unit_web_client.unit, unit_web_client.client, ("oic-auth",))
+    await install_plugins(ops_test, unit_web_client, ("oic-auth",))
 
     # 1. when jenkins security realm is configured with oidc server and login page is requested.
     payload: dict = {


### PR DESCRIPTION
Applicable spec: N/A

### Overview

!This is a draft PR!

1. The workflow fails due to insufficient permissions.
2. The integration tests fails due to an update with blueocean plugin and a bug in jenkins-plugins-manager which doesn't resolve the dependency correctly and one of the dependent plugin downstream is not downloaded which causes the blueocean plugin to break.

### Rationale

To make the integration tests pass.

### Juju Events Changes

none.

### Module Changes

none.

### Library Changes

none.

### Checklist

- [ x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
