### PR TITLE
fix: storage mount defer event & set port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -195,6 +195,8 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         container = self.unit.get_container(JENKINS_SERVICE_NAME)
         if not container.can_connect():
             self.unit.status = ops.WaitingStatus("Waiting for pebble.")
+            # This event should be handled again once the container becomes available.
+            event.defer()
             return
 
         command = [

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,7 +144,6 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             return
 
         self.unit.set_workload_version(version)
-        self.unit.set_ports(jenkins.WEB_PORT)
         self.unit.status = ops.ActiveStatus()
 
     def _remove_unlisted_plugins(self, container: ops.Container) -> ops.StatusBase:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -194,7 +194,6 @@ def test__on_jenkins_pebble_ready(
     assert (
         jenkins_charm.unit.status.name == ACTIVE_STATUS_NAME
     ), f"unit should be in {ACTIVE_STATUS_NAME}"
-    assert jenkins.WEB_PORT in {open_port.port for open_port in harness.model.unit.opened_ports()}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Storage mount event should be handled if the container was not yet ready.
Juju `set_port` on kubernetes errors, contrary to what the documentation suggests. [link to documentation](https://juju.is/docs/sdk/hook-tool#heading--networking).
```
2024-01-02 00:15:54 ERROR juju.worker.uniter.context context.go:1199 cannot apply changes: cannot retrieve ports for unit "jenkins-k8s/0": unit "jenkins-k8s/0" is not assigned to a machine
2024-01-02T00:15:54.898Z [container-agent] 2024-01-02 00:15:54 ERROR juju.worker.uniter.operation runhook.go:153 hook "jenkins-pebble-ready" (via hook dispatching script: dispatch) failed: cannot apply changes: cannot retrieve ports for unit "jenkins-k8s/0": unit "jenkins-k8s/0" is not assigned to a machine
```

### Rationale

The storage mount event does not get handled in a case where the container was not yet ready.
To allow non-failing deployment of Jenkins.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
