### PR TITLE
fix: storage mount

### DIFF
--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -5,17 +5,22 @@ name: jenkins
 summary: Jenkins rock
 description: Jenkins OCI image for the Jenkins charm
 version: "1.0"
-base: ubuntu:22.04
-build-base: ubuntu:22.04
+base: ubuntu@22.04
+build-base: ubuntu@22.04
 license: Apache-2.0
 platforms:
   amd64:
 services:
   jenkins:
-    override: merge
-    summary: The Jenkins server.
-    command: java -Djava.awt.headless=true -jar /srv/jenkins/jenkins.war
+    override: replace
+    summary: jenkins
     startup: enabled
+    command: java -Djava.awt.headless=true -Djava.util.logging.config.file=/var/lib/jenkins/logging.properties -jar /srv/jenkins/jenkins.war
+    environment:
+      JENKINS_HOME: /var/lib/jenkins
+    user: jenkins
+    group: jenkins
+    
 parts:
   add-user:
     plugin: nil

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -61,7 +61,7 @@ Wait until Jenkins service is up.
 is_storage_ready(container: Container) → bool
 ```
 
-Return whether the Jenkins home storage is mounted. 
+Return whether the Jenkins home directory is mounted and owned by jenkins. 
 
 
 
@@ -78,7 +78,7 @@ Return whether the Jenkins home storage is mounted.
 
 
 **Returns:**
- True if storage is mounted, False otherwise. 
+ True if home directory is mounted and owned by jenkins, False otherwise. 
 
 
 ---

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -53,7 +53,37 @@ Wait until Jenkins service is up.
 
 ---
 
-<a href="../src/jenkins.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L177"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `is_storage_ready`
+
+```python
+is_storage_ready(container: Container) → bool
+```
+
+Return whether the Jenkins home storage is mounted. 
+
+
+
+**Args:**
+ 
+ - <b>`container`</b>:  The Jenkins workload container. 
+
+
+
+**Raises:**
+ 
+ - <b>`StorageMountError`</b>:  if there was an error getting storage information. 
+
+
+
+**Returns:**
+ True if storage is mounted, False otherwise. 
+
+
+---
+
+<a href="../src/jenkins.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_admin_credentials`
 
@@ -77,7 +107,7 @@ Retrieve admin credentials.
 
 ---
 
-<a href="../src/jenkins.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L257"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `calculate_env`
 
@@ -95,7 +125,7 @@ Return a dictionary for Jenkins Pebble layer.
 
 ---
 
-<a href="../src/jenkins.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L266"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_version`
 
@@ -119,7 +149,7 @@ Get the Jenkins server version.
 
 ---
 
-<a href="../src/jenkins.py#L412"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L451"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `bootstrap`
 
@@ -145,7 +175,7 @@ Initialize and install Jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L450"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L489"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_node_secret`
 
@@ -176,7 +206,7 @@ Get node secret from jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L509"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L548"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `add_agent_node`
 
@@ -207,7 +237,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L535"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L574"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_agent_node`
 
@@ -233,7 +263,7 @@ Remove a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L588"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L627"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -258,7 +288,7 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
-<a href="../src/jenkins.py#L613"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L652"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_agent_name`
 
@@ -282,7 +312,7 @@ Infer agent name from unit name.
 
 ---
 
-<a href="../src/jenkins.py#L793"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L832"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_unlisted_plugins`
 
@@ -313,7 +343,7 @@ Remove plugins that are not in the list of desired plugins.
 
 ---
 
-<a href="../src/jenkins.py#L889"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L928"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `rotate_credentials`
 
@@ -430,6 +460,37 @@ An error occurred trying to restart Jenkins.
 
 ## <kbd>class</kbd> `JenkinsUpdateError`
 An error occurred trying to update Jenkins. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `StorageMountError`
+Represents an error probing for Jenkins storage mount. 
+
+
+
+**Attributes:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+<a href="../src/jenkins.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Initialize a new instance of the StorageMountError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
 
 
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -251,7 +251,6 @@ The Jenkins k8s operator charm state.
  - <b>`restart_time_range`</b>:  Time range to allow Jenkins to update version. 
  - <b>`agent_relation_meta`</b>:  Metadata of all agents from units related through agent relation. 
  - <b>`deprecated_agent_relation_meta`</b>:  Metadata of all agents from units related through  deprecated agent relation. 
- - <b>`is_storage_ready`</b>:  Whether the Jenkins home storage is mounted. 
  - <b>`proxy_config`</b>:  Proxy configuration to access Jenkins upstream through. 
  - <b>`plugins`</b>:  The list of allowed plugins to install. 
 
@@ -260,7 +259,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L260"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L242"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -36,7 +36,7 @@ class Observer(ops.Object):
             event: The event fired from get-admin-password action.
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
-        if not container.can_connect() or not self.state.is_storage_ready:
+        if not container.can_connect() or not jenkins.is_storage_ready(container):
             event.fail("Service not yet ready.")
             return
         credentials = jenkins.get_admin_credentials(container)
@@ -49,7 +49,7 @@ class Observer(ops.Object):
             event: The rotate credentials event.
         """
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
-        if not container.can_connect() or not self.state.is_storage_ready:
+        if not container.can_connect() or not jenkins.is_storage_ready(container):
             event.fail("Service not yet ready.")
             return
         try:

--- a/src/agent.py
+++ b/src/agent.py
@@ -64,7 +64,7 @@ class Observer(ops.Object):
         # This is to avoid the None type, juju-info binding should not be None.
         assert (binding := self.model.get_binding("juju-info"))  # nosec
         host = binding.network.bind_address
-        if not container.can_connect() or not self.state.is_storage_ready or not host:
+        if not container.can_connect() or not jenkins.is_storage_ready(container) or not host:
             logger.warning("Service not yet ready. Deferring.")
             event.defer()  # The event needs to be handled after Jenkins has started(pebble ready).
             return
@@ -108,7 +108,7 @@ class Observer(ops.Object):
         # This is to avoid the None type, juju-info binding should not be None.
         assert (binding := self.model.get_binding("juju-info"))  # nosec
         host = binding.network.bind_address
-        if not container.can_connect() or not self.state.is_storage_ready or not host:
+        if not container.can_connect() or not jenkins.is_storage_ready(container) or not host:
             logger.warning("Service not yet ready. Deferring.")
             event.defer()  # The event needs to be handled after Jenkins has started(pebble ready).
             return
@@ -148,7 +148,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
-        if not container.can_connect() or not self.state.is_storage_ready:
+        if not container.can_connect() or not jenkins.is_storage_ready(container):
             logger.warning("Relation departed before service ready.")
             return
 
@@ -176,7 +176,7 @@ class Observer(ops.Object):
         """
         # the event unit cannot be None.
         container = self.charm.unit.get_container(JENKINS_SERVICE_NAME)
-        if not container.can_connect() or not self.state.is_storage_ready:
+        if not container.can_connect() or not jenkins.is_storage_ready(container):
             logger.warning("Relation departed before service ready.")
             return
 

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -175,7 +175,7 @@ class StorageMountError(JenkinsBootstrapError):
 
 
 def is_storage_ready(container: ops.Container) -> bool:
-    """Return whether the Jenkins home storage is mounted.
+    """Return whether the Jenkins home directory is mounted and owned by jenkins.
 
     Args:
         container: The Jenkins workload container.
@@ -184,14 +184,14 @@ def is_storage_ready(container: ops.Container) -> bool:
         StorageMountError: if there was an error getting storage information.
 
     Returns:
-        True if storage is mounted, False otherwise.
+        True if home directory is mounted and owned by jenkins, False otherwise.
     """
     mount_info: str = container.pull("/proc/mounts").read()
     if str(JENKINS_HOME_PATH) not in mount_info:
         return False
     proc: ops.pebble.ExecProcess = container.exec(["stat", "-c", "%U", str(JENKINS_HOME_PATH)])
     try:
-        (stdout, _) = proc.wait_output()
+        stdout, _ = proc.wait_output()
     except (ops.pebble.ChangeError, ops.pebble.ExecError) as exc:
         raise StorageMountError("Error fetching storage ownership info.") from exc
     return "jenkins" in stdout

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -158,6 +158,45 @@ def wait_ready(timeout: int = 300, check_interval: int = 10) -> None:
         raise TimeoutError("Timed out waiting for Jenkins to become ready.") from exc
 
 
+class StorageMountError(JenkinsBootstrapError):
+    """Represents an error probing for Jenkins storage mount.
+
+    Attributes:
+        msg: Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the StorageMountError exception.
+
+        Args:
+            msg: Explanation of the error.
+        """
+        self.msg = msg
+
+
+def is_storage_ready(container: ops.Container) -> bool:
+    """Return whether the Jenkins home storage is mounted.
+
+    Args:
+        container: The Jenkins workload container.
+
+    Raises:
+        StorageMountError: if there was an error getting storage information.
+
+    Returns:
+        True if storage is mounted, False otherwise.
+    """
+    mount_info: str = container.pull("/proc/mounts").read()
+    if str(JENKINS_HOME_PATH) not in mount_info:
+        return False
+    proc: ops.pebble.ExecProcess = container.exec(["stat", "-c", "%U", str(JENKINS_HOME_PATH)])
+    try:
+        (stdout, _) = proc.wait_output()
+    except (ops.pebble.ChangeError, ops.pebble.ExecError) as exc:
+        raise StorageMountError("Error fetching storage ownership info.") from exc
+    return "jenkins" in stdout
+
+
 @dataclasses.dataclass(frozen=True)
 class Credentials:
     """Information needed to log into Jenkins.

--- a/src/state.py
+++ b/src/state.py
@@ -218,22 +218,6 @@ class ProxyConfig(BaseModel):
         )
 
 
-def _is_storage_ready(charm: ops.CharmBase) -> bool:
-    """Return whether the Jenkins home storage is mounted.
-
-    Args:
-        charm: The Jenkins k8s charm.
-
-    Returns:
-        True if storage is mounted, False otherwise.
-    """
-    container = charm.unit.get_container(JENKINS_SERVICE_NAME)
-    if not container.can_connect():
-        return False
-    mount_info: str = container.pull("/proc/mounts").read()
-    return str(JENKINS_HOME_PATH) in mount_info
-
-
 @dataclasses.dataclass(frozen=True)
 class State:
     """The Jenkins k8s operator charm state.
@@ -243,7 +227,6 @@ class State:
         agent_relation_meta: Metadata of all agents from units related through agent relation.
         deprecated_agent_relation_meta: Metadata of all agents from units related through
             deprecated agent relation.
-        is_storage_ready: Whether the Jenkins home storage is mounted.
         proxy_config: Proxy configuration to access Jenkins upstream through.
         plugins: The list of allowed plugins to install.
     """
@@ -255,7 +238,6 @@ class State:
     ]
     proxy_config: typing.Optional[ProxyConfig]
     plugins: typing.Optional[typing.Iterable[str]]
-    is_storage_ready: bool
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "State":
@@ -315,7 +297,6 @@ class State:
             restart_time_range=restart_time_range,
             agent_relation_meta=agent_relation_meta_map,
             deprecated_agent_relation_meta=deprecated_agent_meta_map,
-            is_storage_ready=_is_storage_ready(charm=charm),
             plugins=plugins,
             proxy_config=proxy_config,
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -220,7 +220,7 @@ def container_fixture(
                 required_plugins,
                 "--latest",
             ] == argv:
-                return (0, "", "Done")
+                return (0, "Done", "")
             case _ if [
                 "java",
                 f"-Dhttp.proxyHost={proxy_config.http_proxy.host}",
@@ -242,7 +242,9 @@ def container_fixture(
                 required_plugins,
                 "--latest",
             ] == argv:
-                return (0, "", "Done")
+                return (0, "Done", "")
+            case _ if ["stat", "-c", "%U", str(state.JENKINS_HOME_PATH)] == argv:
+                return (0, jenkins.USER, "")
             # pylint: enable=R0801
             case _:
                 raise RuntimeError(f"unknown command: {argv}")
@@ -254,6 +256,9 @@ def container_fixture(
     harness.set_can_connect(container, True)
     harness.register_command_handler(  # type: ignore # pylint: disable=no-member
         container=container, executable="java", handler=cmd_handler
+    )
+    harness.register_command_handler(  # type: ignore # pylint: disable=no-member
+        container=container, executable="stat", handler=cmd_handler
     )
 
     return container

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -3,43 +3,12 @@
 
 """Jenkins-k8s state module tests."""
 import typing
-import unittest.mock
+from unittest.mock import MagicMock
 
 import ops
 import pytest
-from ops.testing import Harness
 
 import state
-from charm import JenkinsK8sOperatorCharm
-
-from .types_ import HarnessWithContainer
-
-
-def test_is_storage_ready_no_container(harness: Harness):
-    """
-    arrange: given Jenkins charm with container not yet ready.
-    act: when is_storage_ready is called.
-    assert: Falsy value is returned.
-    """
-    harness.begin()
-
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-
-    assert not jenkins_charm.state.is_storage_ready
-
-
-def test_is_storage_ready(harness_container: HarnessWithContainer):
-    """
-    arrange: given Jenkins charm with container ready and storage mounted.
-    act: when is_storage_ready is called.
-    assert: Truthy value is returned.
-    """
-    harness = harness_container.harness
-    harness.begin()
-
-    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-
-    assert jenkins_charm.state.is_storage_ready
 
 
 def test_state_invalid_time_config():
@@ -48,7 +17,7 @@ def test_state_invalid_time_config():
     act: when state is initialized through from_charm method.
     assert: CharmConfigInvalidError is raised.
     """
-    mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
+    mock_charm = MagicMock(spec=ops.CharmBase)
     mock_charm.config = {"restart-time-range": "-1"}
 
     with pytest.raises(state.CharmConfigInvalidError):
@@ -61,7 +30,7 @@ def test_state_invalid_time_config():
         pytest.param("", id="empty string"),
     ],
 )
-def test_no_time_range_config(time_range: str, mock_charm: unittest.mock.MagicMock):
+def test_no_time_range_config(time_range: str, mock_charm: MagicMock):
     """
     arrange: given an empty time range config value.
     act: when state is instantiated.
@@ -118,7 +87,7 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
     assert: CharmConfigInvalidError is raised.
     """
     monkeypatch.setattr(state.os, "environ", {"JUJU_CHARM_HTTP_PROXY": "INVALID_URL"})
-    mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
+    mock_charm = MagicMock(spec=ops.CharmBase)
     mock_charm.config = {}
 
     with pytest.raises(state.CharmConfigInvalidError):
@@ -140,7 +109,7 @@ def test_proxyconfig_none(monkeypatch: pytest.MonkeyPatch):
 def test_proxyconfig_from_charm_env(
     monkeypatch: pytest.MonkeyPatch,
     proxy_config: state.ProxyConfig,
-    mock_charm: unittest.mock.MagicMock,
+    mock_charm: MagicMock,
 ):
     """
     arrange: given a monkeypatched os.environ with proxy configurations.
@@ -165,7 +134,7 @@ def test_proxyconfig_from_charm_env(
     assert config.no_proxy == proxy_config.no_proxy
 
 
-def test_plugins_config_none(mock_charm: unittest.mock.MagicMock):
+def test_plugins_config_none(mock_charm: MagicMock):
     """
     arrange: given a charm with no plugins config.
     act: when state is initialized from charm.
@@ -177,7 +146,7 @@ def test_plugins_config_none(mock_charm: unittest.mock.MagicMock):
     assert config.plugins is None
 
 
-def test_plugins_config(mock_charm: unittest.mock.MagicMock):
+def test_plugins_config(mock_charm: MagicMock):
     """
     arrange: given a charm with comma separated plugins.
     act: when state is initialized from charm.
@@ -190,7 +159,7 @@ def test_plugins_config(mock_charm: unittest.mock.MagicMock):
     assert tuple(config.plugins) == ("hello", "world")
 
 
-def test_invalid_num_units(mock_charm: unittest.mock.MagicMock):
+def test_invalid_num_units(mock_charm: MagicMock):
     """
     arrange: given a mock charm with more than 1 unit of deployment.
     act: when state is initialized from charm.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The storage mount, even if `/proc/mount` returns the valid path, isn't quite mounted with proper permissions and the path is wiped out on mount. This change waits for the storage-ready hook to fire first, changing the permissions for the Jenkins home directory, making sure that Jenkins installation happens *after* the storage has been properly mounted.

### Rationale

When storage gets attached during jenkins installation (the /proc/mount will have /var/lib/jenkins) directory - Jenkins errors with file permissions error. This change will make sure that the `storage-mounted` hook will be handled before jenkins_pebble_ready event.

### Juju Events Changes

None.

### Module Changes

jenkins_storage_mounted is migrated from state to jenkins module.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
