### PR TITLE
test: update deprecated label

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -273,7 +273,6 @@ async def jenkins_machine_agents_fixture(
         num_units=num_units,
     )
     await machine_model.create_offer(f"{app.name}:{state.AGENT_RELATION}", state.AGENT_RELATION)
-    await machine_model.create_offer(f"{app.name}:slave", state.DEPRECATED_AGENT_RELATION)
     await machine_model.wait_for_idle(
         apps=[app.name], status="blocked", idle_period=30, timeout=1200, check_freq=5
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -268,7 +268,7 @@ async def jenkins_machine_agents_fixture(
     app: Application = await machine_model.deploy(
         "jenkins-agent",
         channel="latest/edge",
-        config={"labels": "machine"},
+        config={"jenkins_agent_labels": "machine"},
         application_name=f"jenkins-agent-{app_suffix}",
         num_units=num_units,
     )

--- a/tests/integration/test_machine_agent.py
+++ b/tests/integration/test_machine_agent.py
@@ -50,15 +50,3 @@ async def test_jenkins_machine_agent_relation(
 
     # 2. Assert that the agent nodes are deregistered from Jenkins.
     assert not any((application.name in key for key in jenkins_client.get_nodes().keys()))
-
-
-@pytest.mark.usefixtures("machine_deprecated_agent_related_app")
-async def test_jenkins_machine_deprecated_agent_relation(
-    jenkins_machine_agents: Application, jenkins_client: jenkinsapi.jenkins.Jenkins
-):
-    """
-    arrange: given a cross controller cross model jenkins machine agent with an offer.
-    act: when the relation is setup through the offer.
-    assert: the relation succeeds and the agent is able to run jobs successfully.
-    """
-    assert_job_success(jenkins_client, jenkins_machine_agents.name, "machine")

--- a/tests/integration/test_machine_agent.py
+++ b/tests/integration/test_machine_agent.py
@@ -4,7 +4,6 @@
 """Integration tests for jenkins-k8s-operator charm."""
 
 import jenkinsapi.jenkins
-import pytest
 from juju.application import Application
 
 import state


### PR DESCRIPTION
Applicable spec: None.

### Overview

The edge version of Jenkins machine charm deprecates the `label` configuration option.
This PR updates the deprecated `label`.

### Rationale

To update the label configuration option used in latest Jenkins machine agent charm.
https://charmhub.io/jenkins-agent/configure?channel=latest/edge

### Juju Events Changes

None.

### Module Changes

`test/integration/conftest.py` - to deploy jenkins agent machine charm with updated configuration option.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
