### PR TITLE
Add Docker plugin test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,4 @@ options:
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed. 
+    default: "bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth"

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -365,6 +365,23 @@ async def test_bzr_plugin(unit_web_client: UnitWebClient):
     assert "Bazaar" in config_page, f"Bzr configuration option not found. {config_page}"
 
 
+async def test_docker_build_publish_plugin(unit_web_client: UnitWebClient):
+    """
+    arrange: given a Jenkins charm with docker-build-publish plugin installed.
+    act: when a job configuration page is accessed.
+    assert: docker-build-publish plugin option exists.
+    """
+    await install_plugins(unit_web_client, ("docker-build-publish",))
+    unit_web_client.client.create_job("docker_plugin_test", gen_test_job_xml("k8s"))
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/job/docker_plugin_test/configure"
+    )
+    config_page = str(res.content, "utf-8")
+    assert (
+        "Docker Build and Publish" in config_page
+    ), f"docker-build-publish configuration option not found. {config_page}"
+
+
 @pytest.mark.usefixtures("k8s_agent_related_app")
 async def test_rebuilder_plugin(unit_web_client: UnitWebClient):
     """


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add an integration test for the docker-build-publish plugin.

### Rationale

We need to keep track of plugin functionality when updating the charm

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
