### PR TITLE
Add pipeline-groovy-lib plugin test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,4 +17,4 @@ options:
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed. 
-    default: "bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth"
+    default: "bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth,pipeline-groovy-lib"

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -382,6 +382,21 @@ async def test_docker_build_publish_plugin(unit_web_client: UnitWebClient):
     ), f"docker-build-publish configuration option not found. {config_page}"
 
 
+async def test_groovy_libs_plugin(unit_web_client: UnitWebClient):
+    """
+    arrange: given a Jenkins charm with pipeline-groovy-lib plugin installed.
+    act: when a job configuration page is accessed.
+    assert: pipeline-groovy-lib plugin option exists.
+    """
+    await install_plugins(unit_web_client, ("pipeline-groovy-lib",))
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/manage/configure"
+    )
+
+    config_page = str(res.content, "utf-8")
+    assert "Global Pipeline Libraries" in config_page, f"Groovy libs configuration option not found. {config_page}"
+
+
 @pytest.mark.usefixtures("k8s_agent_related_app")
 async def test_rebuilder_plugin(unit_web_client: UnitWebClient):
     """

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -389,12 +389,12 @@ async def test_groovy_libs_plugin(unit_web_client: UnitWebClient):
     assert: pipeline-groovy-lib plugin option exists.
     """
     await install_plugins(unit_web_client, ("pipeline-groovy-lib",))
-    res = unit_web_client.client.requester.get_url(
-        f"{unit_web_client.web}/manage/configure"
-    )
+    res = unit_web_client.client.requester.get_url(f"{unit_web_client.web}/manage/configure")
 
     config_page = str(res.content, "utf-8")
-    assert "Global Pipeline Libraries" in config_page, f"Groovy libs configuration option not found. {config_page}"
+    assert (
+        "Global Pipeline Libraries" in config_page
+    ), f"Groovy libs configuration option not found. {config_page}"
 
 
 @pytest.mark.usefixtures("k8s_agent_related_app")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add an integration test for a commonly used plugin.

### Rationale

We need to keep track of plugin functionality when updating the charm

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
