### PR TITLE
feat: tox build pipeline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,15 @@ setenv =
 passenv =
   PYTHONPATH
 
+[testenv:build]
+description = Build the rock and pack the charm
+allowlist_externals=sh
+commands =
+    sh -c "cd jenkins_rock && rockcraft pack && \
+    sudo skopeo --insecure-policy copy oci-archive:jenkins_1.0_amd64.rock \
+    docker-daemon:localhost:32000/jenkins:test"
+    sh -c "docker push localhost:32000/jenkins:test"
+
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
     sudo skopeo --insecure-policy copy oci-archive:jenkins_1.0_amd64.rock \
     docker-daemon:localhost:32000/jenkins:test"
     sh -c "docker push localhost:32000/jenkins:test"
+    sh -c "charmcraft pack"
 
 [testenv:fmt]
 description = Apply coding style standards to code
@@ -123,7 +124,10 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}integration/requirements.txt
 commands =
-    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} \
+    --jenkins-image=localhost:32000/jenkins:test \
+    --charm-file=./jenkins-k8s_ubuntu-22.04-amd64.charm \
+    --kube-config=~/.kube/config
 
 [testenv:static]
 description = Run static analysis tests

--- a/tox.ini
+++ b/tox.ini
@@ -124,10 +124,11 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}integration/requirements.txt
 commands =
-    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} \
-    --jenkins-image=localhost:32000/jenkins:test \
-    --charm-file=./jenkins-k8s_ubuntu-22.04-amd64.charm \
-    --kube-config=~/.kube/config
+    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    ; uncomment the following lines to use with output of tox -e build.
+    ; --jenkins-image=localhost:32000/jenkins:test \
+    ; --charm-file=./jenkins-k8s_ubuntu-22.04-amd64.charm \
+    ; --kube-config=~/.kube/config
 
 [testenv:static]
 description = Run static analysis tests


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add tox build pipeline for easy building and testing of Jenkins.

### Rationale

For novel charmers to Jenkins-k8s-operator, they might not have background information on how to build and test, given tox integration test requires many extra arguments. This simplifies the whole process to `tox -e build` and `tox -e integration`.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
