### PR TITLE
Add OWASP dependency check test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,4 +17,4 @@ options:
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed. 
-    default: "bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth,pipeline-groovy-lib,kubernetes"
+    default: "git,bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth,pipeline-groovy-lib,dependency-check-jenkins-plugin,kubernetes"

--- a/config.yaml
+++ b/config.yaml
@@ -17,4 +17,4 @@ options:
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed. 
-    default: "git,bazaar,docker-build-publish,ldap,matrix-combinations-parameter,postbuildscript,ssh-agent,blueocean,thinBackup,rebuild,openid,oic-auth,pipeline-groovy-lib,dependency-check-jenkins-plugin,kubernetes"
+    default: "bazaar,blueocean,dependency-check-jenkins-plugin,docker-build-publish,git,kubernetes,ldap,matrix-combinations-parameter,oic-auth,openid,pipeline-groovy-lib,postbuildscript,rebuild,ssh-agent,thinBackup"

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -389,6 +389,30 @@ async def test_docker_build_publish_plugin(unit_web_client: UnitWebClient):
     ), f"docker-build-publish configuration option not found. {config_page}"
 
 
+async def test_dependency_check_plugin(unit_web_client: UnitWebClient):
+    """
+    arrange: given a Jenkins charm with dependency-check-jenkins-plugin plugin installed.
+    act: when a job configuration page is accessed.
+    assert: dependency-check-jenkins-plugin plugin option exists.
+    """
+    await install_plugins(unit_web_client, ("dependency-check-jenkins-plugin",))
+    unit_web_client.client.create_job("deps_plugin_test", gen_test_job_xml("k8s"))
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/job/deps_plugin_test/configure"
+    )
+    job_page = str(res.content, "utf-8")
+    assert (
+        "Invoke Dependency-Check" in job_page
+    ), f"Dependency check job configuration option not found. {job_page}"
+    res = unit_web_client.client.requester.get_url(
+        f"{unit_web_client.web}/manage/configureTools/"
+    )
+    tools_page = str(res.content, "utf-8")
+    assert (
+        "Dependency-Check installations" in tools_page
+    ), f"Dependency check tool configuration option not found. {tools_page}"    
+
+
 async def test_groovy_libs_plugin(unit_web_client: UnitWebClient):
     """
     arrange: given a Jenkins charm with pipeline-groovy-lib plugin installed.

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -404,13 +404,11 @@ async def test_dependency_check_plugin(unit_web_client: UnitWebClient):
     assert (
         "Invoke Dependency-Check" in job_page
     ), f"Dependency check job configuration option not found. {job_page}"
-    res = unit_web_client.client.requester.get_url(
-        f"{unit_web_client.web}/manage/configureTools/"
-    )
+    res = unit_web_client.client.requester.get_url(f"{unit_web_client.web}/manage/configureTools/")
     tools_page = str(res.content, "utf-8")
     assert (
         "Dependency-Check installations" in tools_page
-    ), f"Dependency check tool configuration option not found. {tools_page}"    
+    ), f"Dependency check tool configuration option not found. {tools_page}"
 
 
 async def test_groovy_libs_plugin(unit_web_client: UnitWebClient):


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add an integration test for the dependency-check-jenkins-plugin

### Rationale

Keeping track of the plugin's functionality

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
