### PR TITLE
Add external url and enable websocket config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ options:
       Preferred UTC time range in 24 hour format for restarting Jenkins. If empty, restart will
       take place whenever Jenkins needs to restart. Jenkins will need to restart on the following
       occasion. Plugins that are not part of `allowed-plugins` configuration option are detected.
-      For example, 03-05 will allow Jenkins restart to take place from 3AM UTC to 5AM UTC. 
+      For example, 03-05 will allow Jenkins restart to take place from 3AM UTC to 5AM UTC.
       Awaits for running job completion for 5 minutes.
     default: ""
   allowed-plugins:
@@ -16,5 +16,18 @@ options:
     description: >
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
-      the list. Included plugins are not automatically installed. 
+      the list. Included plugins are not automatically installed.
     default: "bazaar,blueocean,dependency-check-jenkins-plugin,docker-build-publish,git,kubernetes,ldap,matrix-combinations-parameter,oic-auth,openid,pipeline-groovy-lib,postbuildscript,rebuild,reverse-proxy-auth-plugin,ssh-agent,thinBackup"
+  external-url:
+    type: string
+    description: >
+      Configure the charm to use this URL when establishing relations with agent charms.
+      This is useful when connecting agents from outside of the charm's Kubernetes cluster.
+      It is assumed that this url is reachable to the agents.
+    default: ""
+  agent-enable-websocket:
+    type: boolean
+    description: >
+      Configure inbound agents to use Websocket and skip TCP port 50000.
+      This is useful when the charm is deployed behind a reverse-proxy or behind a firewall.
+    default: false

--- a/src/agent.py
+++ b/src/agent.py
@@ -80,6 +80,7 @@ class Observer(ops.Object):
             event.defer()
             return
 
+        enable_websocket = bool(self.state.agent_enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
             jenkins.add_agent_node(
@@ -87,14 +88,20 @@ class Observer(ops.Object):
                 container=container,
                 # mypy doesn't understand that host can no longer be None.
                 host=host,
+                enable_websocket=enable_websocket,
             )
             secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        jenkins_url = (
+            f"http://{host}:{jenkins.WEB_PORT}"
+            if self.state.external_url
+            else str(self.state.external_url)
+        )
         event.relation.data[self.model.unit].update(
-            AgentRelationData(url=f"http://{host}:{jenkins.WEB_PORT}", secret=secret)
+            AgentRelationData(url=jenkins_url, secret=secret)
         )
         self.charm.unit.status = ops.ActiveStatus()
 
@@ -124,17 +131,28 @@ class Observer(ops.Object):
             event.defer()
             return
 
+        enable_websocket = bool(self.state.agent_enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
-            jenkins.add_agent_node(agent_meta=agent_meta, container=container, host=host)
+            jenkins.add_agent_node(
+                agent_meta=agent_meta,
+                container=container,
+                host=host,
+                enable_websocket=enable_websocket,
+            )
             secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        jenkins_url = (
+            f"http://{host}:{jenkins.WEB_PORT}"
+            if self.state.external_url
+            else str(self.state.external_url)
+        )
         event.relation.data[self.model.unit].update(
             {
-                "url": f"http://{host}:{jenkins.WEB_PORT}",
+                "url": jenkins_url,
                 f"{agent_meta.name}_secret": secret,
             }
         )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
