### PR TITLE
Enable ingress integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
       channel: 1.28-strict/stable
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
-      modules: '["test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
+      modules: '["test_ingress.py", "test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
       pre-run-script: |
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
         chmod +x tests/integration/pre_run_script.sh

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -20,5 +20,4 @@ class Observer(ops.Object):
         """
         super().__init__(charm, "ingress-observer")
         self.charm = charm
-
-        self.ingress = IngressPerAppRequirer(self.charm, port=jenkins.WEB_PORT)
+        self.ingress = IngressPerAppRequirer(self.charm, port=jenkins.WEB_PORT, strip_prefix=True)

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 WEB_PORT = 8080
 WEB_URL = f"http://localhost:{WEB_PORT}"
-LOGIN_URL = f"{WEB_URL}/login?from=%2F"
+LOGIN_PATH = "/login?from=%2F"
+LOGIN_URL = f"{WEB_URL}{LOGIN_PATH}"
 EXECUTABLES_PATH = Path("/srv/jenkins/")
 # Path to initial Jenkins password file
 PASSWORD_FILE_PATH = JENKINS_HOME_PATH / "secrets/initialAdminPassword"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -792,7 +792,10 @@ async def ingress_application_related_fixture(application: Application, external
         "traefik-k8s",
         channel="1.0/stable",
         trust=True,
-        config={"external_hostname": external_hostname},
+        config={
+            "external_hostname": external_hostname,
+            "routing_mode": "subdomain",
+        },
     )
     await application.model.wait_for_idle(
         status="active", apps=[traefik.name], raise_on_error=False, timeout=30 * 60
@@ -805,4 +808,4 @@ async def ingress_application_related_fixture(application: Application, external
         idle_period=30,
         raise_on_error=False,
     )
-    return traefik
+    return application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -808,4 +808,4 @@ async def ingress_application_related_fixture(application: Application, external
         idle_period=30,
         raise_on_error=False,
     )
-    return application
+    return traefik

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -3,6 +3,9 @@
 
 """Integration tests for jenkins-k8s-operator with ingress."""
 
+
+# pylint: disable=unused-argument
+
 import pytest
 import requests
 from juju.application import Application
@@ -13,19 +16,19 @@ import jenkins
 
 @pytest.mark.abort_on_fail
 async def test_ingress_integration(
-    model: Model, ingress_related: Application, external_hostname: str
+    model: Model, application: Application, ingress_related: Application, external_hostname: str
 ):
     """
     arrange: deploy the Jenkins charm and establish relations via ingress.
     act: send a request to the ingress in /.
     assert: the response succeeds.
     """
-    status = await model.get_status(filters=[ingress_related.name])
-    unit = next(iter(status.applications[ingress_related.name].units))
-    address = status["applications"][ingress_related.name]["units"][unit]["address"]
+    status = await model.get_status(filters=[application.name])
+    unit = next(iter(status.applications[application.name].units))
+    address = status["applications"][application.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
-        headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},
+        f"http://{address}:8080{jenkins.LOGIN_PATH}",
+        headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     )
     assert response.status_code == 200

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -21,10 +21,10 @@ async def test_ingress_integration(
     status = await model.get_status(filters=[ingress_related.name])
     unit = next(iter(status.applications[ingress_related.name].units))
     address = status["applications"][ingress_related.name]["units"][unit]["address"]
-    print(address)
     response = requests.get(
         f"http://{address}",
         headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
-    ).json()
+    )
+    print(response)
     assert response.status_code == 200

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -8,10 +8,12 @@ import requests
 from juju.application import Application
 from juju.model import Model
 
+import jenkins
+
 
 @pytest.mark.abort_on_fail
 async def test_ingress_integration(
-    model: Model, application: Application, ingress_related: Application, external_hostname: str
+    model: Model, ingress_related: Application, external_hostname: str
 ):
     """
     arrange: deploy the Jenkins charm and establish relations via ingress.
@@ -22,10 +24,8 @@ async def test_ingress_integration(
     unit = next(iter(status.applications[ingress_related.name].units))
     address = status["applications"][ingress_related.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}",
-        headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
+        f"http://{address}:8080{jenkins.LOGIN_PATH}",
+        headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},
         timeout=5,
     )
-    print(response)
-    print(response.content)
     assert response.status_code == 200

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -11,7 +11,7 @@ from juju.model import Model
 
 @pytest.mark.abort_on_fail
 async def test_ingress_integration(
-    model: Model, ingress_related: Application, external_hostname: str
+    model: Model, application: Application, ingress_related: Application, external_hostname: str
 ):
     """
     arrange: deploy the Jenkins charm and establish relations via ingress.
@@ -21,9 +21,10 @@ async def test_ingress_integration(
     status = await model.get_status(filters=[ingress_related.name])
     unit = next(iter(status.applications[ingress_related.name].units))
     address = status["applications"][ingress_related.name]["units"][unit]["address"]
+    print(address)
     response = requests.get(
         f"http://{address}",
-        headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},
+        headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     ).json()
     assert response.status_code == 200

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -27,7 +27,7 @@ async def test_ingress_integration(
     unit = next(iter(status.applications[application.name].units))
     address = status["applications"][application.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}:8080{jenkins.LOGIN_PATH}",
+        f"http://{address}:{jenkins.PORT}{jenkins.LOGIN_PATH}",
         headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     )

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -27,4 +27,5 @@ async def test_ingress_integration(
         timeout=5,
     )
     print(response)
+    print(response.content)
     assert response.status_code == 200

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -20,7 +20,7 @@ async def test_ingress_integration(
     """
     status = await model.get_status(filters=[ingress_related.name])
     unit = next(iter(status.applications[ingress_related.name].units))
-    address = status["applications"][app.name]["units"][unit]["address"]
+    address = status["applications"][ingress_related.name]["units"][unit]["address"]
     response = requests.get(
         f"http://{address}",
         headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -27,7 +27,7 @@ async def test_ingress_integration(
     unit = next(iter(status.applications[application.name].units))
     address = status["applications"][application.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}:{jenkins.PORT}{jenkins.LOGIN_PATH}",
+        f"http://{address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
         headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     )

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -20,8 +20,9 @@ async def test_ingress_integration(
     """
     status = await model.get_status(filters=[ingress_related.name])
     unit = next(iter(status.applications[ingress_related.name].units))
+    address = status["applications"][app.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{unit.address}",
+        f"http://{address}",
         headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},
         timeout=5,
     ).json()

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -24,7 +24,7 @@ async def test_ingress_integration(
     unit = next(iter(status.applications[ingress_related.name].units))
     address = status["applications"][ingress_related.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}:8080{jenkins.LOGIN_PATH}",
+        f"http://{address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
         headers={"Host": f"{model.name}-{ingress_related.name}.{external_hostname}"},
         timeout=5,
     )


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Enable ingress integration test

### Rationale

<!-- The reason the change is needed -->
The existing integration test for the ingress v2 relation is not being executed

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
