### PR TITLE
Add docs for agent discovery

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ options:
       Preferred UTC time range in 24 hour format for restarting Jenkins. If empty, restart will
       take place whenever Jenkins needs to restart. Jenkins will need to restart on the following
       occasion. Plugins that are not part of `allowed-plugins` configuration option are detected.
-      For example, 03-05 will allow Jenkins restart to take place from 3AM UTC to 5AM UTC. 
+      For example, 03-05 will allow Jenkins restart to take place from 3AM UTC to 5AM UTC.
       Awaits for running job completion for 5 minutes.
     default: ""
   allowed-plugins:
@@ -16,5 +16,18 @@ options:
     description: >
       Comma-separated list of allowed plugin short names. If empty, any plugin can be installed.
       Plugins installed by the user and their dependencies will be removed automatically if not on
-      the list. Included plugins are not automatically installed. 
+      the list. Included plugins are not automatically installed.
     default: "bazaar,blueocean,dependency-check-jenkins-plugin,docker-build-publish,git,kubernetes,ldap,matrix-combinations-parameter,oic-auth,openid,pipeline-groovy-lib,postbuildscript,rebuild,reverse-proxy-auth-plugin,ssh-agent,thinBackup"
+  external-url:
+    type: string
+    description: >
+      Configure the charm to use this URL when establishing relations with agent charms.
+      This is useful when connecting agents from outside of the charm's Kubernetes cluster.
+      It is assumed that this url is reachable to the agents.
+    default: ""
+  agent-enable-websocket:
+    type: boolean
+    description: >
+      Configure inbound agents to use Websocket and skip TCP port 50000.
+      This is useful when the charm is deployed behind a reverse-proxy or behind a firewall.
+    default: false

--- a/config.yaml
+++ b/config.yaml
@@ -18,14 +18,15 @@ options:
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed.
     default: "bazaar,blueocean,dependency-check-jenkins-plugin,docker-build-publish,git,kubernetes,ldap,matrix-combinations-parameter,oic-auth,openid,pipeline-groovy-lib,postbuildscript,rebuild,reverse-proxy-auth-plugin,ssh-agent,thinBackup"
-  external-url:
+  remoting-external-url:
     type: string
     description: >
       Configure the charm to use this URL when establishing relations with agent charms.
       This is useful when connecting agents from outside of the charm's Kubernetes cluster.
-      It is assumed that this url is reachable to the agents.
+      It is assumed that this url is reachable to the agents. A schema (http:// or https://)
+      is required
     default: ""
-  agent-enable-websocket:
+  remoting-enable-websocket:
     type: boolean
     description: >
       Configure inbound agents to use Websocket and skip TCP port 50000.

--- a/src/agent.py
+++ b/src/agent.py
@@ -80,7 +80,7 @@ class Observer(ops.Object):
             event.defer()
             return
 
-        enable_websocket = bool(self.state.agent_enable_websocket)
+        enable_websocket = bool(self.state.remoting_config.enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
             jenkins.add_agent_node(
@@ -95,10 +95,11 @@ class Observer(ops.Object):
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        configured_remoting_external_url = self.state.remoting_config.external_url
         jenkins_url = (
             f"http://{host}:{jenkins.WEB_PORT}"
-            if self.state.external_url
-            else str(self.state.external_url)
+            if not configured_remoting_external_url
+            else str(configured_remoting_external_url)
         )
         event.relation.data[self.model.unit].update(
             AgentRelationData(url=jenkins_url, secret=secret)
@@ -131,7 +132,7 @@ class Observer(ops.Object):
             event.defer()
             return
 
-        enable_websocket = bool(self.state.agent_enable_websocket)
+        enable_websocket = bool(self.state.remoting_config.enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
             jenkins.add_agent_node(
@@ -145,10 +146,11 @@ class Observer(ops.Object):
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        configured_remoting_external_url = self.state.remoting_config.external_url
         jenkins_url = (
             f"http://{host}:{jenkins.WEB_PORT}"
-            if self.state.external_url
-            else str(self.state.external_url)
+            if not configured_remoting_external_url
+            else str(configured_remoting_external_url)
         )
         event.relation.data[self.model.unit].update(
             {

--- a/src/agent.py
+++ b/src/agent.py
@@ -80,6 +80,7 @@ class Observer(ops.Object):
             event.defer()
             return
 
+        enable_websocket = bool(self.state.agent_enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
             jenkins.add_agent_node(
@@ -87,14 +88,20 @@ class Observer(ops.Object):
                 container=container,
                 # mypy doesn't understand that host can no longer be None.
                 host=host,
+                enable_websocket=enable_websocket,
             )
             secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        jenkins_url = (
+            f"http://{host}:{jenkins.WEB_PORT}"
+            if self.state.external_url
+            else str(self.state.external_url)
+        )
         event.relation.data[self.model.unit].update(
-            AgentRelationData(url=f"http://{host}:{jenkins.WEB_PORT}", secret=secret)
+            AgentRelationData(url=jenkins_url, secret=secret)
         )
         self.charm.unit.status = ops.ActiveStatus()
 
@@ -124,17 +131,28 @@ class Observer(ops.Object):
             event.defer()
             return
 
+        enable_websocket = bool(self.state.agent_enable_websocket)
         self.charm.unit.status = ops.MaintenanceStatus("Adding agent node.")
         try:
-            jenkins.add_agent_node(agent_meta=agent_meta, container=container, host=host)
+            jenkins.add_agent_node(
+                agent_meta=agent_meta,
+                container=container,
+                host=host,
+                enable_websocket=enable_websocket,
+            )
             secret = jenkins.get_node_secret(container=container, node_name=agent_meta.name)
         except jenkins.JenkinsError as exc:
             self.charm.unit.status = ops.BlockedStatus(f"Jenkins API exception. {exc=!r}")
             return
 
+        jenkins_url = (
+            f"http://{host}:{jenkins.WEB_PORT}"
+            if self.state.external_url
+            else str(self.state.external_url)
+        )
         event.relation.data[self.model.unit].update(
             {
-                "url": f"http://{host}:{jenkins.WEB_PORT}",
+                "url": jenkins_url,
                 f"{agent_meta.name}_secret": secret,
             }
         )

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -521,6 +521,7 @@ def _get_node_config(
         agent_meta: The Jenkins agent metadata to create the node from.
         container: The Jenkins workload container.
         host: The Jenkins server ip address for direct agent tunnel connection.
+        enable_websocket: Whether to use websocket for inbound agent connections.
 
     Returns:
         A dictionary mapping of agent configuration values.
@@ -542,7 +543,7 @@ def _get_node_config(
     meta = json.loads(attribs["json"])
     # Websocket is mutually exclusive with tunnel connect through
     if enable_websocket:
-        meta["enable-websocket"] = enable_websocket
+        meta["launcher"]["webSocket"] = enable_websocket
     else:
         # the field can either take "HOST:PORT", ":PORT", or "HOST:"
         meta["launcher"]["tunnel"] = f"{host}:"
@@ -562,6 +563,7 @@ def add_agent_node(
         agent_meta: The Jenkins agent metadata to create the node from.
         container: The Jenkins workload container.
         host: The Jenkins server ip address for direct agent tunnel connection.
+        enable_websocket: Whether to use websocket for inbound agent connections.
 
     Raises:
         JenkinsError: if an error occurred running groovy script creating the node.

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -602,6 +602,7 @@ def test_add_agent_node_fail(
             state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
             container,
             host=mock_ip_addr,
+            enable_websocket=False,
         )
 
 
@@ -620,6 +621,7 @@ def test_add_agent_node_already_exists(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
         container,
         host=mock_ip_addr,
+        enable_websocket=False,
     )
 
 
@@ -638,6 +640,26 @@ def test_add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
         container,
         host=mock_ip_addr,
+        enable_websocket=False,
+    )
+
+
+@pytest.mark.usefixtures("patch_jenkins_node")
+def test_add_agent_node_websocket(
+    container: ops.Container, mock_client: MagicMock, mock_ip_addr: IPv4Address
+):
+    """
+    arrange: given a mocked jenkins client.
+    act: when add_agent is called.
+    assert: no exception is raised.
+    """
+    mock_client.create_node_with_config.return_value = MagicMock(spec=jenkins.Node)
+
+    jenkins.add_agent_node(
+        state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
+        container,
+        host=mock_ip_addr,
+        enable_websocket=True,
     )
 
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -169,3 +169,18 @@ def test_invalid_num_units(mock_charm: MagicMock):
 
     with pytest.raises(state.CharmIllegalNumUnitsError):
         state.State.from_charm(mock_charm)
+
+
+def test_remotingconfig_invalid(mock_charm: MagicMock):
+    """
+    arrange: given a mock charm with invalid remoting configuration.
+    act: when charm state is initialized.
+    assert: CharmConfigInvalidError is raised.
+    """
+    mock_charm.config = {
+        "remoting-external-url": "invalid",
+        "remoting-enable-websocket": "invalid",
+    }
+
+    with pytest.raises(state.CharmConfigInvalidError):
+        state.State.from_charm(mock_charm)


### PR DESCRIPTION
Add docs for configuring jenkins when machine/k8s agents don't have direct pod IP access.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
