### PR TITLE
ISD-1622 Jenkins agent discovery with ingress

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,9 +9,8 @@ jobs:
     secrets: inherit
     with:
       channel: 1.28-strict/stable
-      extra-arguments: >-
+      extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
-        --cloud microk8s
       modules: '["test_ingress.py", "test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
       pre-run-script: |
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,6 +11,7 @@ jobs:
       channel: 1.28-strict/stable
       extra-arguments: |
         --kube-config ${GITHUB_WORKSPACE}/kube-config
+        --cloud microk8s
       modules: '["test_ingress.py", "test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'
       pre-run-script: |
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,7 +9,7 @@ jobs:
     secrets: inherit
     with:
       channel: 1.28-strict/stable
-      extra-arguments: |
+      extra-arguments: >-
         --kube-config ${GITHUB_WORKSPACE}/kube-config
         --cloud microk8s
       modules: '["test_ingress.py", "test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_cos.py"]'

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,10 @@ CVE-2016-1000027
 # Jenkins Plugin Manager CVEs
 CVE-2023-5072
 GHSA-4jq9-2xhw-jpx7
+# Fix hasn't been released upstream
+# https://github.com/jenkinsci/jenkins/pull/8971
+CVE-2024-25710
+CVE-2024-26308
+# https://github.com/jenkinsci/jenkins/pull/8696
+# Fixed in 5.3.32
+CVE-2024-22243

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,4 +3,11 @@ CVE-2016-1000027
 # Jenkins Plugin Manager CVEs
 CVE-2023-5072
 GHSA-4jq9-2xhw-jpx7
+# Fix hasn't been released upstream
+# https://github.com/jenkinsci/jenkins/pull/8971
+CVE-2024-25710
+CVE-2024-26308
+# https://github.com/jenkinsci/jenkins/pull/8696
+# Fixed in 5.3.32
+CVE-2024-22243
 CVE-2024-22201

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,10 +3,4 @@ CVE-2016-1000027
 # Jenkins Plugin Manager CVEs
 CVE-2023-5072
 GHSA-4jq9-2xhw-jpx7
-# Fix hasn't been released upstream
-# https://github.com/jenkinsci/jenkins/pull/8971
-CVE-2024-25710
-CVE-2024-26308
-# https://github.com/jenkinsci/jenkins/pull/8696
-# Fixed in 5.3.32
-CVE-2024-22243
+CVE-2024-22201

--- a/config.yaml
+++ b/config.yaml
@@ -18,17 +18,3 @@ options:
       Plugins installed by the user and their dependencies will be removed automatically if not on
       the list. Included plugins are not automatically installed.
     default: "bazaar,blueocean,dependency-check-jenkins-plugin,docker-build-publish,git,kubernetes,ldap,matrix-combinations-parameter,oic-auth,openid,pipeline-groovy-lib,postbuildscript,rebuild,reverse-proxy-auth-plugin,ssh-agent,thinBackup"
-  remoting-external-url:
-    type: string
-    description: >
-      Configure the charm to use this URL when establishing relations with agent charms.
-      This is useful when connecting agents from outside of the charm's Kubernetes cluster.
-      It is assumed that this url is reachable to the agents. A schema (http:// or https://)
-      is required
-    default: ""
-  remoting-enable-websocket:
-    type: boolean
-    description: >
-      Configure inbound agents to use Websocket and skip TCP port 50000.
-      This is useful when the charm is deployed behind a reverse-proxy or behind a firewall.
-    default: false

--- a/docs/how-to/integrate-with-external-agents.md
+++ b/docs/how-to/integrate-with-external-agents.md
@@ -17,4 +17,4 @@ juju integrate jenkins-k8s:agent <offer-endpoint>
 The charm assumes that:
 1. There are connectivity between the juju controller of the `jenkins-k8s` charm and the juju controller of the agent charm trying to connect with the `jenkins-k8s` charm.
 2. The agent can resolve the ingress hostname provided by the `jenkins-k8s` charm and the resulting IP address is reachable, and there are firewall rules in place to allow HTTP traffic.
-3. In case a reverse proxy is present, it is also expected that the HTTP connection coming from the agent charm is allowed to be upgraded into a Websocket connection.
+3. In case a reverse proxy is present, it is also expected that the HTTP connection coming from the agent charm is allowed to be upgraded into a Websocket connection. The reverse proxy should also be configured with a suitable idle timeout for websocket connections to avoid intermittent agent disconnection.

--- a/docs/how-to/integrate-with-external-agents.md
+++ b/docs/how-to/integrate-with-external-agents.md
@@ -1,0 +1,20 @@
+# How to integrate with external agent charms
+
+We consider any agent charm to be `external` when they don't have layer 3 connectivity with the `jenkins-k8s` charm. To integrate with those agent charms, we'll leverage the `jenkins-k8s` charm's `agent-discovery-ingress` integration.
+
+The `agent-discovery-ingress` integration can be used with any charm that supports the `:ingress` interface. One example is the [traefik-k8s](https://charmhub.io/traefik-k8s) charm.
+```bash
+juju integrate jenkins-k8s:agent-discovery-ingress traefik-k8s:ingress
+```
+
+Agents considered `external` have to be integrated using a cross-model integration. To integrate with such agent, simply integrate with the ingress provider charm as mentioned above and then integrate with the agent charm's offer endpoint.
+```bash
+juju integrate jenkins-k8s:agent-discovery-ingress traefik-k8s:ingress
+juju integrate jenkins-k8s:agent <offer-endpoint>
+```
+
+# Networking considerations
+The charm assumes that:
+1. There are connectivity between the juju controller of the `jenkins-k8s` charm and the juju controller of the agent charm trying to connect with the `jenkins-k8s` charm.
+2. The agent can resolve the ingress hostname provided by the `jenkins-k8s` charm and the resulting IP address is reachable, and there are firewall rules in place to allow HTTP traffic.
+3. In case a reverse proxy is present, it is also expected that the HTTP connection coming from the agent charm is allowed to be upgraded into a Websocket connection.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -59,6 +59,10 @@ requires:
     interface: ingress
     optional: true
     limit: 1
+  agent-discovery-ingress:
+    interface: ingress
+    optional: true
+    limit: 1
   logging:
     interface: loki_push_api
 provides:

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -33,12 +33,18 @@ Relation data required for adding the Jenkins agent.
 ## <kbd>class</kbd> `Observer`
 The Jenkins agent relation observer. 
 
-<a href="../src/agent.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+
+**Attributes:**
+ 
+ - <b>`agent_discovery_url`</b>:  external hostname to be passed to agents for discovery. 
+
+<a href="../src/agent.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: CharmBase, state: State)
+__init__(charm: CharmBase, state: State, ingress_observer: Observer)
 ```
 
 Initialize the observer and register event handlers. 
@@ -49,7 +55,21 @@ Initialize the observer and register event handlers.
  
  - <b>`charm`</b>:  The parent charm to attach the observer to. 
  - <b>`state`</b>:  The charm state. 
+ - <b>`ingress_observer`</b>:  The ingress observer responsible for agent discovery. 
 
+
+---
+
+#### <kbd>property</kbd> agent_discovery_url
+
+Return the external hostname to be passed to agents via the integration. 
+
+If we do not have an ingress, then use the pod ip as hostname. The reason to prefer this over the pod name (which is the actual hostname visible from the pod) or a K8s service, is that those are routable virtually exclusively inside the cluster (as they rely) on the cluster's DNS service, while the ip address is _sometimes_ routable from the outside, e.g., when deploying on MicroK8s on Linux. 
+
+
+
+**Returns:**
+  The charm's agent discovery url. 
 
 ---
 
@@ -58,5 +78,19 @@ Initialize the observer and register event handlers.
 Shortcut for more simple access the model. 
 
 
+
+---
+
+<a href="../src/agent.py#L255"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `reconfigure_agent_discovery`
+
+```python
+reconfigure_agent_discovery(_: EventBase) → None
+```
+
+Update the agent discovery URL in each of the connected agent's integration data. 
+
+Will cause agents to restart!! 
 
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,14 +8,15 @@ Charm Jenkins.
 **Global Variables**
 ---------------
 - **JENKINS_SERVICE_NAME**
+- **AGENT_DISCOVERY_INGRESS_RELATION_NAME**
 
 
 ---
 
 ## <kbd>class</kbd> `JenkinsK8sOperatorCharm`
-Charm Jenkins. 
+Charmed Jenkins. 
 
-<a href="../src/charm.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/ingress.py.md
+++ b/src-docs/ingress.py.md
@@ -12,12 +12,12 @@ Observer module for Jenkins to ingress integration.
 ## <kbd>class</kbd> `Observer`
 The Jenkins Ingress integration observer. 
 
-<a href="../src/ingress.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/ingress.py#L17"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(charm: CharmBase)
+__init__(charm: CharmBase, key: str, relation_name: Optional[str] = None)
 ```
 
 Initialize the observer and register event handlers. 
@@ -27,6 +27,8 @@ Initialize the observer and register event handlers.
 **Args:**
  
  - <b>`charm`</b>:  The parent charm to attach the observer to. 
+ - <b>`key`</b>:  The ops's Object identifier, to have a unique path for event handling. 
+ - <b>`relation_name`</b>:  The ingress relation that this observer is managing. 
 
 
 ---

--- a/src-docs/jenkins.py.md
+++ b/src-docs/jenkins.py.md
@@ -9,6 +9,7 @@ Functions to operate Jenkins.
 ---------------
 - **WEB_PORT**
 - **WEB_URL**
+- **LOGIN_PATH**
 - **LOGIN_URL**
 - **REQUIRED_PLUGINS**
 - **USER**
@@ -206,16 +207,12 @@ Get node secret from jenkins.
 
 ---
 
-<a href="../src/jenkins.py#L548"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L546"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `add_agent_node`
 
 ```python
-add_agent_node(
-    agent_meta: AgentMeta,
-    container: Container,
-    host: Union[IPv4Address, IPv6Address, str]
-) → None
+add_agent_node(agent_meta: AgentMeta, container: Container) → None
 ```
 
 Add a Jenkins agent node. 
@@ -226,7 +223,6 @@ Add a Jenkins agent node.
  
  - <b>`agent_meta`</b>:  The Jenkins agent metadata to create the node from. 
  - <b>`container`</b>:  The Jenkins workload container. 
- - <b>`host`</b>:  The Jenkins server ip address for direct agent tunnel connection. 
 
 
 
@@ -237,7 +233,7 @@ Add a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L574"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L567"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_agent_node`
 
@@ -263,7 +259,7 @@ Remove a Jenkins agent node.
 
 ---
 
-<a href="../src/jenkins.py#L627"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L620"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `safe_restart`
 
@@ -288,7 +284,7 @@ Safely restart Jenkins server after all jobs are done executing.
 
 ---
 
-<a href="../src/jenkins.py#L652"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L645"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_agent_name`
 
@@ -312,7 +308,7 @@ Infer agent name from unit name.
 
 ---
 
-<a href="../src/jenkins.py#L832"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L825"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_unlisted_plugins`
 
@@ -343,7 +339,7 @@ Remove plugins that are not in the list of desired plugins.
 
 ---
 
-<a href="../src/jenkins.py#L928"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/jenkins.py#L921"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `rotate_credentials`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -259,7 +259,7 @@ The Jenkins k8s operator charm state.
 
 ---
 
-<a href="../src/state.py#L242"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L243"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -79,7 +79,7 @@ class Observer(ops.Object):
         If we do not have an ingress, then use the pod ip as hostname.
         The reason to prefer this over the pod name (which is the actual
         hostname visible from the pod) or a K8s service, is that those
-        are routable virtually exclusively inside the cluster (as they rely)
+        are routable virtually exclusively inside the cluster as they rely
         on the cluster's DNS service, while the ip address is _sometimes_
         routable from the outside, e.g., when deploying on MicroK8s on Linux.
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -89,11 +89,11 @@ class Observer(ops.Object):
         try:
             if ingress_url := self.ingress_observer.ingress.url:
                 return ingress_url
-        except ops.ModelError as e:
+        except ops.ModelError as exc:
             # We only log the error here as we can fallback to using pod IP
             # if ingress is not available
             logger.error(
-                "Failed obtaining agent discovery url: %s, is the charm shutting down?", e
+                "Failed obtaining agent discovery url: %s, is the charm shutting down?", exc
             )
         # Fallback to pod IP
         return f"http://{socket.getfqdn()}:{jenkins.WEB_PORT}"

--- a/src/agent.py
+++ b/src/agent.py
@@ -82,8 +82,8 @@ class Observer(ops.Object):
         on the cluster's DNS service, while the ip address is _sometimes_
         routable from the outside, e.g., when deploying on MicroK8s on Linux.
 
-        Attributes:
-            charm: The charm root JenkinsK8SOperatorCharm.
+        Returns:
+            The charm's agent discovery url.
         """
         # Check if an ingress URL is available
         try:

--- a/src/agent.py
+++ b/src/agent.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """The Jenkins agent relation observer."""
+import ipaddress
 import logging
 import socket
 import typing
@@ -95,8 +96,31 @@ class Observer(ops.Object):
             logger.error(
                 "Failed obtaining agent discovery url: %s, is the charm shutting down?", exc
             )
+
         # Fallback to pod IP
+        if binding := self.charm.model.get_binding("juju-info"):
+            unit_ip = str(binding.network.bind_address)
+            if self._is_valid_ip_address(unit_ip):
+                return f"http://{unit_ip}:{jenkins.WEB_PORT}"
+
+        # Fallback to fqdn
         return f"http://{socket.getfqdn()}:{jenkins.WEB_PORT}"
+
+    def _is_valid_ip_address(self, address: str) -> bool:
+        """Validate an IP address.
+
+        Args:
+            address: a string representing a unit address
+
+        Returns:
+            Whether the IP address is a valid unit IP address
+        """
+        try:
+            _ = ipaddress.ip_address(address)
+        except ValueError:
+            return False
+
+        return True
 
     def _on_deprecated_agent_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
         """Handle deprecated agent relation joined event.

--- a/src/agent.py
+++ b/src/agent.py
@@ -116,7 +116,7 @@ class Observer(ops.Object):
             Whether the IP address is a valid unit IP address
         """
         try:
-            _ = ipaddress.ip_address(address)
+            ipaddress.ip_address(address)
         except ValueError:
             return False
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -66,11 +66,11 @@ class Observer(ops.Object):
         # Event hooks for agent-discovery-ingress
         charm.framework.observe(
             ingress_observer.ingress.on.ready,
-            self._on_ready,
+            self._ingress_on_ready,
         )
         charm.framework.observe(
             ingress_observer.ingress.on.revoked,
-            self._on_revoked,
+            self._ingress_on_revoked,
         )
 
     @property
@@ -242,22 +242,6 @@ class Observer(ops.Object):
             return
         self.charm.unit.status = ops.ActiveStatus()
 
-    def _on_ready(self, event: IngressPerAppReadyEvent) -> None:
-        """Handle ready event for agent-discovery-ingress.
-
-        Args:
-            event: The event fired.
-        """
-        self.reconfigure_agent_discovery(event)
-
-    def _on_revoked(self, event: IngressPerAppRevokedEvent) -> None:
-        """Handle revoked event for agent-discovery-ingress.
-
-        Args:
-            event: The event fired.
-        """
-        self.reconfigure_agent_discovery(event)
-
     def reconfigure_agent_discovery(self, _: ops.EventBase) -> None:
         """Update the agent discovery URL in each of the connected agent's integration data.
 
@@ -268,3 +252,19 @@ class Observer(ops.Object):
             if relation_discovery_url and relation_discovery_url == self.agent_discovery_url:
                 continue
             relation.data[self.model.unit].update({"url": self.agent_discovery_url})
+
+    def _ingress_on_ready(self, event: IngressPerAppReadyEvent) -> None:
+        """Handle ready event for agent-discovery-ingress.
+
+        Args:
+            event: The event fired.
+        """
+        self.reconfigure_agent_discovery(event)
+
+    def _ingress_on_revoked(self, event: IngressPerAppRevokedEvent) -> None:
+        """Handle revoked event for agent-discovery-ingress.
+
+        Args:
+            event: The event fired.
+        """
+        self.reconfigure_agent_discovery(event)

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,6 +27,7 @@ from state import (
 if typing.TYPE_CHECKING:
     from ops.pebble import LayerDict  # pragma: no cover
 
+AGENT_DISCOVERY_INGRESS_RELATION_NAME = "agent-discovery-ingress"
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,10 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         self.actions_observer = actions.Observer(self, self.state)
         self.agent_observer = agent.Observer(self, self.state)
         self.cos_observer = cos.Observer(self)
-        self.ingress_observer = ingress.Observer(self)
+        self.ingress_observer = ingress.Observer(self, AGENT_DISCOVERY_INGRESS_RELATION_NAME)
+        # Ingress dedicated to agent discovery
+        self.agent_discovery_ingress_observer = ingress.Observer(self)
+
         self.framework.observe(
             self.on.jenkins_home_storage_attached, self._on_jenkins_home_storage_attached
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ if typing.TYPE_CHECKING:
     from ops.pebble import LayerDict  # pragma: no cover
 
 AGENT_DISCOVERY_INGRESS_RELATION_NAME = "agent-discovery-ingress"
-
+INGRESS_RELATION_NAME = "ingress"
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +62,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             self, self.state, self.agent_discovery_ingress_observer
         )
         self.cos_observer = cos.Observer(self)
-        self.ingress_observer = ingress.Observer(self, "ingress-observer")
+        self.ingress_observer = ingress.Observer(self, "ingress-observer", INGRESS_RELATION_NAME)
         self.framework.observe(
             self.on.jenkins_home_storage_attached, self._on_jenkins_home_storage_attached
         )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -3,8 +3,6 @@
 
 """Observer module for Jenkins to ingress integration."""
 
-import typing
-
 import ops
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 
@@ -14,7 +12,7 @@ import jenkins
 class Observer(ops.Object):
     """The Jenkins Ingress integration observer."""
 
-    def __init__(self, charm: ops.CharmBase, key: str, relation_name: typing.Optional[str] = None):
+    def __init__(self, charm: ops.CharmBase, key: str, relation_name: str):
         """Initialize the observer and register event handlers.
 
         Args:
@@ -24,12 +22,9 @@ class Observer(ops.Object):
         """
         super().__init__(charm, key)
         self.charm = charm
-        requirer_args = {}
-        if relation_name:
-            requirer_args["relation_name"] = relation_name
         self.ingress = IngressPerAppRequirer(
             self.charm,
-            **requirer_args,
+            relation_name=relation_name,
             port=jenkins.WEB_PORT,
             strip_prefix=True,
         )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -14,20 +14,20 @@ import jenkins
 class Observer(ops.Object):
     """The Jenkins Ingress integration observer."""
 
-    def __init__(self, charm: ops.CharmBase, relation_name: typing.Optional[str] = None):
+    def __init__(self, charm: ops.CharmBase, key: str, relation_name: typing.Optional[str] = None):
         """Initialize the observer and register event handlers.
 
         Args:
             charm: The parent charm to attach the observer to.
         """
-        super().__init__(charm, "ingress-observer")
+        super().__init__(charm, key)
         self.charm = charm
         requirer_args = {}
         if relation_name:
             requirer_args["relation_name"] = relation_name
         self.ingress = IngressPerAppRequirer(
             self.charm,
-            *requirer_args,
+            **requirer_args,
             port=jenkins.WEB_PORT,
             strip_prefix=True,
         )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -3,6 +3,8 @@
 
 """Observer module for Jenkins to ingress integration."""
 
+import typing
+
 import ops
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 
@@ -12,7 +14,7 @@ import jenkins
 class Observer(ops.Object):
     """The Jenkins Ingress integration observer."""
 
-    def __init__(self, charm: ops.CharmBase):
+    def __init__(self, charm: ops.CharmBase, relation_name: typing.Optional[str] = None):
         """Initialize the observer and register event handlers.
 
         Args:
@@ -20,4 +22,12 @@ class Observer(ops.Object):
         """
         super().__init__(charm, "ingress-observer")
         self.charm = charm
-        self.ingress = IngressPerAppRequirer(self.charm, port=jenkins.WEB_PORT, strip_prefix=True)
+        requirer_args = {}
+        if relation_name:
+            requirer_args["relation_name"] = relation_name
+        self.ingress = IngressPerAppRequirer(
+            self.charm,
+            *requirer_args,
+            port=jenkins.WEB_PORT,
+            strip_prefix=True,
+        )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -19,6 +19,8 @@ class Observer(ops.Object):
 
         Args:
             charm: The parent charm to attach the observer to.
+            key: The ops's Object identifier, to have a unique path for event handling.
+            relation_name: The ingress relation that this observer is managing.
         """
         super().__init__(charm, key)
         self.charm = charm

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -13,7 +13,6 @@ import secrets
 import textwrap
 import typing
 from datetime import datetime, timedelta
-from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
 from time import sleep
 
@@ -519,7 +518,6 @@ def _get_node_config(
     Args:
         agent_meta: The Jenkins agent metadata to create the node from.
         container: The Jenkins workload container.
-        host: The Jenkins server ip address for direct agent tunnel connection.
 
     Returns:
         A dictionary mapping of agent configuration values.
@@ -551,8 +549,6 @@ def add_agent_node(agent_meta: state.AgentMeta, container: ops.Container) -> Non
     Args:
         agent_meta: The Jenkins agent metadata to create the node from.
         container: The Jenkins workload container.
-        host: The Jenkins server ip address for direct agent tunnel connection.
-        enable_websocket: Whether to use websocket for inbound agent connections.
 
     Raises:
         JenkinsError: if an error occurred running groovy script creating the node.

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -513,8 +513,6 @@ def get_node_secret(node_name: str, container: ops.Container) -> str:
 def _get_node_config(
     agent_meta: state.AgentMeta,
     container: ops.Container,
-    host: typing.Union[IPv4Address, IPv6Address, str],
-    enable_websocket: bool,
 ) -> dict[str, typing.Any]:
     """Get agent node configuration dictionary values.
 
@@ -522,7 +520,6 @@ def _get_node_config(
         agent_meta: The Jenkins agent metadata to create the node from.
         container: The Jenkins workload container.
         host: The Jenkins server ip address for direct agent tunnel connection.
-        enable_websocket: Whether to use websocket for inbound agent connections.
 
     Returns:
         A dictionary mapping of agent configuration values.
@@ -542,22 +539,13 @@ def _get_node_config(
     )
     attribs = node.get_node_attributes()
     meta = json.loads(attribs["json"])
-    # Websocket is mutually exclusive with tunnel connect through
-    if enable_websocket:
-        meta["launcher"]["webSocket"] = enable_websocket
-    else:
-        # the field can either take "HOST:PORT", ":PORT", or "HOST:"
-        meta["launcher"]["tunnel"] = f"{host}:"
+
+    meta["launcher"]["webSocket"] = True
     attribs["json"] = json.dumps(meta)
     return attribs
 
 
-def add_agent_node(
-    agent_meta: state.AgentMeta,
-    container: ops.Container,
-    host: typing.Union[IPv4Address, IPv6Address, str],
-    enable_websocket: bool,
-) -> None:
+def add_agent_node(agent_meta: state.AgentMeta, container: ops.Container) -> None:
     """Add a Jenkins agent node.
 
     Args:
@@ -571,12 +559,7 @@ def add_agent_node(
     """
     client = _get_client(_get_api_credentials(container))
     try:
-        config = _get_node_config(
-            agent_meta=agent_meta,
-            container=container,
-            host=host,
-            enable_websocket=enable_websocket,
-        )
+        config = _get_node_config(agent_meta=agent_meta, container=container)
         client.create_node_with_config(name=agent_meta.name, config=config)
     except jenkinsapi.custom_exceptions.AlreadyExists:
         pass

--- a/src/state.py
+++ b/src/state.py
@@ -6,18 +6,16 @@ import dataclasses
 import functools
 import logging
 import os
+import socket
 import typing
 from pathlib import Path
 
 import ops
 from pydantic import (
-    AnyHttpUrl,
     BaseModel,
     Field,
     HttpUrl,
-    StrictBool,
     ValidationError,
-    tools,
     validator,
 )
 
@@ -30,6 +28,7 @@ DEPRECATED_AGENT_RELATION = "agent-deprecated"
 JENKINS_SERVICE_NAME = "jenkins"
 JENKINS_HOME_STORAGE_NAME = "jenkins-home"
 JENKINS_HOME_PATH = Path("/var/lib/jenkins")
+WEB_PORT = 8080
 
 
 class CharmStateBaseError(Exception):
@@ -196,6 +195,30 @@ def _get_agent_meta_map_from_relation(
     return unit_metadata_mapping
 
 
+def _get_agent_discovery_url_from_charm(charm: ops.CharmBase) -> str:
+    """Return the external hostname to be passed to agents via the integration.
+    If we do not have an ingress, then use the pod ip as hostname.
+    The reason to prefer this over the pod name (which is the actual
+    hostname visible from the pod) or a K8s service, is that those
+    are routable virtually exclusively inside the cluster (as they rely)
+    on the cluster's DNS service, while the ip address is _sometimes_
+    routable from the outside, e.g., when deploying on MicroK8s on Linux.
+
+    Attributes:
+        charm: The charm root JenkinsK8SOperatorCharm.
+    """
+
+    # Check if an ingress URL is available
+    try:
+        if ingress_url := charm.agent_discovery_ingress_observer.ingress.url:
+            return ingress_url
+    except ops.ModelError as e:
+        # We only log the error here as we can fallback to using pod IP if ingress is not available
+        logger.error("Failed obtaining external url: %s. Shutting down?", e)
+    # Fallback to pod IP
+    return f"http://{socket.getfqdn()}:{WEB_PORT}"
+
+
 class ProxyConfig(BaseModel):
     """Configuration for accessing Jenkins through proxy.
 
@@ -227,40 +250,6 @@ class ProxyConfig(BaseModel):
         )
 
 
-class RemotingConfig(BaseModel):
-    """Configuration for inbound agent connections.
-
-    Attributes:
-        external_url: External URL for inbound agent connections.
-        enable_websocket: Use websocket for inbound agent connections.
-    """
-
-    external_url: typing.Optional[AnyHttpUrl]
-    enable_websocket: StrictBool
-
-    @classmethod
-    def from_config(cls, config: ops.ConfigData) -> "RemotingConfig":
-        """Instantiate RemotingConfig from juju charm config data.
-
-        Args:
-            config: the charm's config data
-
-        Returns:
-            RemotingConfig with validated attributes.
-        """
-        config_remoting_external_url = config.get("remoting-external-url")
-        external_url = (
-            tools.parse_obj_as(AnyHttpUrl, config_remoting_external_url)
-            if config_remoting_external_url
-            else None
-        )
-        enable_websocket = bool(config.get("remoting-enable-websocket"))
-        return cls(
-            external_url=external_url,
-            enable_websocket=enable_websocket,
-        )
-
-
 @dataclasses.dataclass(frozen=True)
 class State:
     """The Jenkins k8s operator charm state.
@@ -272,7 +261,6 @@ class State:
             deprecated agent relation.
         proxy_config: Proxy configuration to access Jenkins upstream through.
         plugins: The list of allowed plugins to install.
-        remoting_config: Configuration for inbound agents.
 
     """
 
@@ -283,7 +271,7 @@ class State:
     ]
     proxy_config: typing.Optional[ProxyConfig]
     plugins: typing.Optional[typing.Iterable[str]]
-    remoting_config: RemotingConfig
+    agent_discovery_url: str
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "State":
@@ -301,7 +289,6 @@ class State:
             CharmIllegalNumUnitsError: if more than 1 unit of Jenkins charm is deployed.
         """
         try:
-            remoting_config = RemotingConfig.from_config(config=charm.config)
             time_range_str = charm.config.get("restart-time-range")
             if time_range_str:
                 restart_time_range = Range.from_str(time_range_str)
@@ -310,9 +297,6 @@ class State:
         except InvalidTimeRangeError as exc:
             logger.error("Invalid config value for restart-time-range, %s", exc)
             raise CharmConfigInvalidError("Invalid config value for restart-time range.") from exc
-        except ValidationError as exc:
-            logger.error("Invalid charm configuration, %s", exc)
-            raise CharmConfigInvalidError("Invalid charm configuration.") from exc
 
         try:
             agent_relation_meta_map = _get_agent_meta_map_from_relation(
@@ -347,5 +331,5 @@ class State:
             deprecated_agent_relation_meta=deprecated_agent_meta_map,
             plugins=plugins,
             proxy_config=proxy_config,
-            remoting_config=remoting_config,
+            agent_discovery_url=_get_agent_discovery_url_from_charm(charm=charm),
         )

--- a/src/state.py
+++ b/src/state.py
@@ -21,7 +21,6 @@ DEPRECATED_AGENT_RELATION = "agent-deprecated"
 JENKINS_SERVICE_NAME = "jenkins"
 JENKINS_HOME_STORAGE_NAME = "jenkins-home"
 JENKINS_HOME_PATH = Path("/var/lib/jenkins")
-WEB_PORT = 8080
 
 
 class CharmStateBaseError(Exception):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -785,7 +785,7 @@ def external_hostname_fixture() -> str:
     return "juju.test"
 
 
-@pytest_asyncio.fixture(scope="function", name="traefik_application")
+@pytest_asyncio.fixture(scope="module", name="traefik_application")
 async def traefik_application_fixture(model: Model, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -788,7 +788,7 @@ def external_hostname_fixture() -> str:
     return "juju.test"
 
 
-@pytest_asyncio.fixture(scope="module", name="traefik_application")
+@pytest_asyncio.fixture(scope="module", name="traefik_application_and_unit_ip")
 async def traefik_application_fixture(model: Model, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(
@@ -809,4 +809,8 @@ async def traefik_application_fixture(model: Model, external_hostname: str):
         raise_on_error=False,
     )
 
-    yield traefik
+    status = await model.get_status(filters=[traefik.name])
+    unit = next(iter(status.applications[traefik.name].units))
+    traefik_address = status["applications"][traefik.name]["units"][unit]["address"]
+
+    return (traefik, traefik_address)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,6 +38,12 @@ def model_fixture(ops_test: OpsTest) -> Model:
     return ops_test.model
 
 
+@pytest.fixture(scope="module", name="cloud")
+def cloud_fixture(ops_test: OpsTest) -> typing.Optional[str]:
+    """The cloud the k8s model is running on."""
+    return ops_test.cloud_name
+
+
 @pytest.fixture(scope="module", name="jenkins_image")
 def jenkins_image_fixture(request: FixtureRequest) -> str:
     """The OCI image for Jenkins charm."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -809,3 +809,28 @@ async def ingress_application_related_fixture(application: Application, external
         raise_on_error=False,
     )
     return traefik
+
+
+@pytest_asyncio.fixture(scope="module", name="traefik_application")
+async def traefik_application_fixture(model: Model, external_hostname: str):
+    """The application related to Jenkins via ingress v2 relation."""
+    traefik = await model.deploy(
+        "traefik-k8s",
+        channel="1.0/stable",
+        trust=True,
+        config={
+            "external_hostname": external_hostname,
+            "routing_mode": "subdomain",
+        },
+    )
+    await model.wait_for_idle(
+        status="active", apps=[traefik.name], raise_on_error=False, timeout=30 * 60
+    )
+    await model.wait_for_idle(
+        status="active",
+        apps=[traefik.name],
+        timeout=20 * 60,
+        idle_period=30,
+        raise_on_error=False,
+    )
+    return traefik

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -785,7 +785,7 @@ def external_hostname_fixture() -> str:
     return "juju.test"
 
 
-@pytest_asyncio.fixture(scope="module", name="ingress_related")
+@pytest_asyncio.fixture(scope="function", name="ingress_related")
 async def ingress_application_related_fixture(application: Application, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await application.model.deploy(
@@ -811,7 +811,7 @@ async def ingress_application_related_fixture(application: Application, external
     return traefik
 
 
-@pytest_asyncio.fixture(scope="module", name="traefik_application")
+@pytest_asyncio.fixture(scope="function", name="traefik_application")
 async def traefik_application_fixture(model: Model, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -178,7 +178,7 @@ async def jenkins_k8s_agents_fixture(
         "jenkins-agent-k8s",
         config={"jenkins_agent_labels": "k8s"},
         channel="latest/edge",
-        application_name=f"jenkins-agentk8s-{app_suffix}",
+        application_name=f"jenkins-agent-k8s-{app_suffix}",
     )
     await model.wait_for_idle(apps=[agent_app.name], status="blocked")
 
@@ -797,9 +797,7 @@ async def traefik_application_fixture(model: Model, external_hostname: str):
             "routing_mode": "subdomain",
         },
     )
-    await model.wait_for_idle(
-        status="active", apps=[traefik.name], raise_on_error=False, timeout=30 * 60
-    )
+
     await model.wait_for_idle(
         status="active",
         apps=[traefik.name],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -255,6 +255,9 @@ async def machine_model_fixture(
 
     yield model
 
+    await machine_controller.destroy_models(
+        model.name, destroy_storage=True, force=True, max_wait=10 * 60
+    )
     await model.disconnect()
 
 
@@ -785,7 +788,7 @@ def external_hostname_fixture() -> str:
     return "juju.test"
 
 
-@pytest_asyncio.fixture(scope="function", name="traefik_application")
+@pytest_asyncio.fixture(scope="module", name="traefik_application")
 async def traefik_application_fixture(model: Model, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(
@@ -807,5 +810,3 @@ async def traefik_application_fixture(model: Model, external_hostname: str):
     )
 
     yield traefik
-
-    await model.remove_application(traefik.name, block_until_done=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -785,7 +785,7 @@ def external_hostname_fixture() -> str:
     return "juju.test"
 
 
-@pytest_asyncio.fixture(scope="module", name="traefik_application")
+@pytest_asyncio.fixture(scope="function", name="traefik_application")
 async def traefik_application_fixture(model: Model, external_hostname: str):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -29,12 +29,11 @@ async def test_ingress_integration(
     assert: the response succeeds.
     """
     await application.relate("ingress", traefik_application.name)
-
-    status = await model.get_status(filters=[traefik_application.name])
-    unit = next(iter(status.applications[traefik_application.name].units))
-    traefik_address = status["applications"][traefik_application.name]["units"][unit]["address"]
+    status = await model.get_status(filters=[application.name, traefik_application.name])
+    unit = next(iter(status.applications[application.name].units))
+    address = status["applications"][application.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{traefik_address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
+        f"http://{address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
         headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     )

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 from juju.application import Application
 from juju.model import Model
+from juju.controller import Controller
 
 import jenkins
 import state
@@ -58,6 +59,9 @@ async def test_agent_discovery_ingress_integration(
     act: integrate the charms with each other and update the machine agent's dns record.
     assert: All units should be in active status.
     """
+    controller: Controller = await model.get_controller()
+    cloud = await controller.get_cloud()
+    assert cloud == "microk8s", "This test can only be run on microk8s"
     traefik_application, traefik_address = traefik_application_and_unit_ip
     await application.relate(
         AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -12,6 +12,8 @@ from juju.application import Application
 from juju.model import Model
 
 import jenkins
+import state
+from charm import AGENT_DISCOVERY_INGRESS_RELATION_NAME
 
 
 @pytest.mark.abort_on_fail
@@ -32,3 +34,35 @@ async def test_ingress_integration(
         timeout=5,
     )
     assert response.status_code == 200
+
+
+@pytest.mark.abort_on_fail
+async def test_agent_discovery_ingress_integration(
+    model: Model,
+    application: Application,
+    traefik_application: Application,
+    external_hostname: str,
+    jenkins_k8s_agents: Application,
+):
+    """
+    arrange: deploy the Jenkins charm and establish relations via ingress.
+    act: send a request to the ingress in /.
+    assert: the response succeeds.
+    """
+    await application.relate(state.AGENT_RELATION, jenkins_k8s_agents.name)
+    await application.relate(AGENT_DISCOVERY_INGRESS_RELATION_NAME, traefik_application.name)
+
+    await model.wait_for_idle(
+        apps=[application.name, jenkins_k8s_agents.name, traefik_application.name],
+        wait_for_active=True,
+    )
+
+    agent_discovery_url_verified = False
+    for relation in application.relations:
+        if set([jenkins_k8s_agents.name, application.name]) == set(relation.applications):
+            assert (
+                relation.data[application.units[0].name]["url"]
+                == f"{model.name}-{application.name}.{external_hostname}"
+            )
+            agent_discovery_url_verified = True
+    assert agent_discovery_url_verified

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -11,8 +11,8 @@ import typing
 import pytest
 import requests
 from juju.application import Application
-from juju.model import Model
 from juju.controller import Controller
+from juju.model import Model
 
 import jenkins
 import state

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -47,7 +47,6 @@ async def test_ingress_integration(
 # This will only work on microk8s !!
 @pytest.mark.abort_on_fail
 async def test_agent_discovery_ingress_integration(
-    cloud: typing.Optional[str],
     application: Application,
     traefik_application_and_unit_ip: typing.Tuple[Application, str],
     external_hostname: str,
@@ -60,7 +59,6 @@ async def test_agent_discovery_ingress_integration(
     """
     model = application.model
     machine_model = jenkins_machine_agents.model
-    assert cloud == "microk8s", "This test can only be run on microk8s"
     traefik_application, traefik_address = traefik_application_and_unit_ip
     await application.relate(
         AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 from juju.application import Application
 from juju.model import Model
+from juju.unit import Unit
 
 import jenkins
 import state
@@ -29,44 +30,55 @@ async def test_ingress_integration(
     assert: the response succeeds.
     """
     await application.relate("ingress", traefik_application.name)
-    status = await model.get_status(filters=[application.name, traefik_application.name])
-    unit = next(iter(status.applications[application.name].units))
-    address = status["applications"][application.name]["units"][unit]["address"]
+    # Find traefik IP
+    status = await model.get_status(filters=[traefik_application.name])
+    unit = next(iter(status.applications[traefik_application.name].units))
+    traefik_address = status["applications"][traefik_application.name]["units"][unit]["address"]
     response = requests.get(
-        f"http://{address}:{jenkins.WEB_PORT}{jenkins.LOGIN_PATH}",
+        f"http://{traefik_address}",
         headers={"Host": f"{model.name}-{application.name}.{external_hostname}"},
         timeout=5,
     )
     assert response.status_code == 200
 
 
+# This will only work on microk8s !!
 @pytest.mark.abort_on_fail
 async def test_agent_discovery_ingress_integration(
     model: Model,
     application: Application,
     traefik_application: Application,
     external_hostname: str,
-    jenkins_k8s_agents: Application,
+    jenkins_machine_agents: Application,
 ):
     """
     arrange: deploy the Jenkins charm and establish relations via ingress.
     act: send a request to the ingress in /.
     assert: the response succeeds.
     """
-    await application.relate(state.AGENT_RELATION, jenkins_k8s_agents.name)
-    await application.relate(AGENT_DISCOVERY_INGRESS_RELATION_NAME, traefik_application.name)
-
-    await model.wait_for_idle(
-        apps=[application.name, jenkins_k8s_agents.name, traefik_application.name],
-        wait_for_active=True,
+    await application.relate(
+        AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"
     )
+    # Find traefik IP
+    status = await model.get_status(filters=[traefik_application.name])
+    unit = next(iter(status.applications[traefik_application.name].units))
+    traefik_address = status["applications"][traefik_application.name]["units"][unit]["address"]
+    # Add dns record
+    command = f"sudo echo '{traefik_address} {model.name}-{application.name}.{external_hostname}' >> /etc/hosts"
+    for unit in jenkins_machine_agents.units:
+        action = await unit.run(command)
+        await action.wait()
 
-    agent_discovery_url_verified = False
-    for relation in application.relations:
-        if set([jenkins_k8s_agents.name, application.name]) == set(relation.applications):
-            assert (
-                relation.data[application.units[0].name]["url"]
-                == f"{model.name}-{application.name}.{external_hostname}"
-            )
-            agent_discovery_url_verified = True
-    assert agent_discovery_url_verified
+    model = application.model
+    machine_model = jenkins_machine_agents.model
+    # this code is similar to the machine_agent_related_app fixture but shouldn't be using the
+    # fixture since this test tests for teardown of relation as well.
+    # pylint: disable=duplicate-code
+    await model.relate(
+        f"{application.name}:{state.AGENT_RELATION}",
+        f"localhost:admin/{machine_model.name}.{state.AGENT_RELATION}",
+    )
+    await machine_model.wait_for_idle(
+        apps=[jenkins_machine_agents.name], wait_for_active=True, raise_on_error=False
+    )
+    await model.wait_for_idle(apps=[application.name], wait_for_active=True)

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -67,17 +67,16 @@ async def test_agent_discovery_ingress_integration(
         AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"
     )
     # Add dns record
-    ingress_hostname = f"{traefik_address} {model.name}-{application.name}.{external_hostname}"
-    command = f"sudo echo '{ingress_hostname}' >> /etc/hosts"
+    ingress_hostname_mapping = (
+        f"{traefik_address} {model.name}-{application.name}.{external_hostname}"
+    )
+    command = f"sudo echo '{ingress_hostname_mapping}' >> /etc/hosts"
     for unit in jenkins_machine_agents.units:
         action = await unit.run(command)
         await action.wait()
 
     model = application.model
     machine_model = jenkins_machine_agents.model
-    # this code is similar to the machine_agent_related_app fixture but shouldn't be using the
-    # fixture since this test tests for teardown of relation as well.
-    # pylint: disable=duplicate-code
     await model.relate(
         f"{application.name}:{state.AGENT_RELATION}",
         f"localhost:admin/{machine_model.name}.{state.AGENT_RELATION}",

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -510,6 +510,32 @@ def test_reconfigure_agent_discovery_url(
     )
 
 
+def test_reconfigure_agent_discovery_url_ingress_revoked(
+    harness: Harness,
+    get_relation_data: Callable[[str], dict[str, str]],
+):
+    """
+    arrange: given a base jenkins charm integrated with the jenkins-agent charm with ingress.
+    act: remove the traefik integration.
+    assert: the discovery url in the integration databag is different from the ingress url.
+    """
+    mock_ingress_url = "http://ingress.test"
+    ingress_relation_id = harness.add_relation(
+        "agent-discovery-ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": mock_ingress_url})},
+    )
+    relation_id = harness.add_relation(
+        state.AGENT_RELATION, "jenkins-agent", unit_data=get_relation_data(state.AGENT_RELATION)
+    )
+    harness.begin()
+
+    harness.remove_relation(ingress_relation_id)
+    assert (
+        harness.get_relation_data(relation_id, harness.model.unit.name)["url"] != mock_ingress_url
+    )
+
+
 def test_reconfigure_agent_discovery_url_unchanged(
     harness: Harness,
     get_relation_data: Callable[[str], dict[str, str]],

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -6,12 +6,16 @@
 # Need access to protected functions for testing
 # pylint:disable=protected-access
 
+import json
 import secrets
+import socket
 import unittest.mock
 from typing import Callable, cast
 
 import jenkinsapi
 import pytest
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops import ModelError
 from ops.charm import PebbleReadyEvent
 
 import charm
@@ -20,7 +24,7 @@ import state
 from charm import JenkinsK8sOperatorCharm
 
 from .helpers import ACTIVE_STATUS_NAME, BLOCKED_STATUS_NAME, MAINTENANCE_STATUS_NAME
-from .types_ import HarnessWithContainer
+from .types_ import Harness, HarnessWithContainer
 
 
 @pytest.mark.parametrize(
@@ -356,3 +360,120 @@ def test__on_agent_relation_departed(
     assert jenkins_charm.unit.status.name == ACTIVE_STATUS_NAME
     assert not jenkins_charm.unit.status.message
     mocked_remove_agent.assert_called_once()
+
+
+def test_agent_discovery_url(harness: Harness, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given a base jenkins charm with no ingress.
+    act: access the charm's agent_discovery_url property.
+    assert: the charm returns the value from socket.get_fqdn().
+    """
+    harness.begin()
+    mock_fqdn = "test"
+    monkeypatch.setattr(socket, "getfqdn", unittest.mock.MagicMock(return_value=mock_fqdn))
+
+    assert (
+        harness.charm.agent_observer.agent_discovery_url
+        == f"http://{mock_fqdn}:{jenkins.WEB_PORT}"
+    )
+
+
+def test_agent_discovery_url_with_ingress(harness: Harness):
+    """
+    arrange: given a base jenkins charm with ingress integration.
+    act: start the charm and add an ingress integration with traefik.
+    assert: charm.agent_observer.agent_discovery_url is the value
+    from the ingress integration databag.
+    """
+    harness.begin()
+
+    mock_ingress_url = "http://ingress.test"
+    harness.add_relation(
+        "agent-discovery-ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": mock_ingress_url})},
+    )
+
+    assert harness.charm.agent_observer.agent_discovery_url == mock_ingress_url
+
+
+def test_agent_discovery_url_with_ingress_model_error(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    arrange: given a base jenkins charm and mocked ingress requirer to raise ModelError.
+    act: start the charm and add an ingress integration with traefik.
+    assert: charm.agent_observer.agent_discovery_url is the value from socket.get_fqdn().
+    """
+    mock_fqdn = "test"
+    monkeypatch.setattr(socket, "getfqdn", unittest.mock.MagicMock(return_value=mock_fqdn))
+    monkeypatch.setattr(
+        IngressPerAppRequirer, "url", unittest.mock.PropertyMock(side_effect=ModelError)
+    )
+
+    harness.begin()
+    harness.add_relation(
+        "agent-discovery-ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": "http://ingress.test"})},
+    )
+
+    assert (
+        harness.charm.agent_observer.agent_discovery_url
+        == f"http://{mock_fqdn}:{jenkins.WEB_PORT}"
+    )
+
+
+def test_reconfigure_agent_discovery_url(
+    harness: Harness,
+    get_relation_data: Callable[[str], dict[str, str]],
+):
+    """
+    arrange: given a base jenkins charm integrated with the jenkins-agent charm.
+    act: add an integration with traefik.
+    assert: the discovery url in the integration databag is changed to the ingress url.
+    """
+    relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins-agent")
+    harness.add_relation_unit(relation_id, "jenkins-agent/0")
+    harness.update_relation_data(
+        relation_id, "jenkins-agent/0", get_relation_data(state.AGENT_RELATION)
+    )
+    harness.begin()
+
+    mock_ingress_url = "http://ingress.test"
+    harness.add_relation(
+        "agent-discovery-ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": mock_ingress_url})},
+    )
+
+    assert (
+        harness.get_relation_data(relation_id, harness.model.unit.name)["url"] == mock_ingress_url
+    )
+
+
+def test_reconfigure_agent_discovery_url_unchanged(
+    harness: Harness,
+    get_relation_data: Callable[[str], dict[str, str]],
+):
+    """
+    arrange: given a base jenkins charm integrated with the jenkins-agent charm.
+    The integration databag contains an agent discovery url.
+    act: add an integration with traefik providing the same url.
+    assert: the discovery url in the integration databag is not changed.
+    """
+    mock_ingress_url = "http://ingress.test"
+    relation_id = harness.add_relation(
+        state.AGENT_RELATION, "jenkins-agent", unit_data=get_relation_data(state.AGENT_RELATION)
+    )
+    harness.update_relation_data(relation_id, harness.model.unit.name, {"url": mock_ingress_url})
+    harness.begin()
+    harness.add_relation(
+        "agent-discovery-ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": mock_ingress_url})},
+    )
+
+    assert (
+        harness.get_relation_data(relation_id, harness.model.unit.name)["url"] == mock_ingress_url
+    )

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -15,7 +15,6 @@ import textwrap
 import typing
 import unittest.mock
 from functools import partial
-from ipaddress import IPv4Address
 from unittest.mock import MagicMock
 
 import jenkinsapi.jenkins
@@ -585,9 +584,7 @@ def test_get_node_secret(container: ops.Container, mock_client: MagicMock):
 
 
 @pytest.mark.usefixtures("patch_jenkins_node")
-def test_add_agent_node_fail(
-    container: ops.Container, mock_client: MagicMock, mock_ip_addr: IPv4Address
-):
+def test_add_agent_node_fail(container: ops.Container, mock_client: MagicMock):
     """
     arrange: given a mocked jenkins client that raises an API exception.
     act: when add_agent is called
@@ -601,15 +598,11 @@ def test_add_agent_node_fail(
         jenkins.add_agent_node(
             state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
             container,
-            host=mock_ip_addr,
-            enable_websocket=False,
         )
 
 
 @pytest.mark.usefixtures("patch_jenkins_node")
-def test_add_agent_node_already_exists(
-    container: ops.Container, mock_client: MagicMock, mock_ip_addr: IPv4Address
-):
+def test_add_agent_node_already_exists(container: ops.Container, mock_client: MagicMock):
     """
     arrange: given a mocked jenkins client that raises an Already exists exception.
     act: when add_agent is called.
@@ -620,15 +613,11 @@ def test_add_agent_node_already_exists(
     jenkins.add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
         container,
-        host=mock_ip_addr,
-        enable_websocket=False,
     )
 
 
 @pytest.mark.usefixtures("patch_jenkins_node")
-def test_add_agent_node(
-    container: ops.Container, mock_client: MagicMock, mock_ip_addr: IPv4Address
-):
+def test_add_agent_node(container: ops.Container, mock_client: MagicMock):
     """
     arrange: given a mocked jenkins client.
     act: when add_agent is called.
@@ -639,15 +628,11 @@ def test_add_agent_node(
     jenkins.add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
         container,
-        host=mock_ip_addr,
-        enable_websocket=False,
     )
 
 
 @pytest.mark.usefixtures("patch_jenkins_node")
-def test_add_agent_node_websocket(
-    container: ops.Container, mock_client: MagicMock, mock_ip_addr: IPv4Address
-):
+def test_add_agent_node_websocket(container: ops.Container, mock_client: MagicMock):
     """
     arrange: given a mocked jenkins client.
     act: when add_agent is called.
@@ -658,8 +643,6 @@ def test_add_agent_node_websocket(
     jenkins.add_agent_node(
         state.AgentMeta(executors="3", labels="x86_64", name="agent_node_0"),
         container,
-        host=mock_ip_addr,
-        enable_websocket=True,
     )
 
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -169,18 +169,3 @@ def test_invalid_num_units(mock_charm: MagicMock):
 
     with pytest.raises(state.CharmIllegalNumUnitsError):
         state.State.from_charm(mock_charm)
-
-
-def test_remotingconfig_invalid(mock_charm: MagicMock):
-    """
-    arrange: given a mock charm with invalid remoting configuration.
-    act: when charm state is initialized.
-    assert: CharmConfigInvalidError is raised.
-    """
-    mock_charm.config = {
-        "remoting-external-url": "invalid",
-        "remoting-enable-websocket": "invalid",
-    }
-
-    with pytest.raises(state.CharmConfigInvalidError):
-        state.State.from_charm(mock_charm)


### PR DESCRIPTION
Applicable spec: ISD-126 (internal)

It's currently not possible for the [Jenkins charm](https://charmhub.io/jenkins-k8s) to establish a working cross-model relation with [machine agent charms ](https://charmhub.io/jenkins-agent)that does not have access to the k8s pod IP (only possible in microk8s) and with k8s agent charms that are not in the same cluster due to the Pod IP being hard-coded in the relation data bag.

This PR will add another ingress integration, called `agent-discovery-ingress`, which will be used for external agent discovery.

This PR will also enable websocket for all inbound agent connections. Using WebSocket, inbound agents can now be connected much more simply when a reverse proxy is present: if the HTTP(S) port is already serving traffic, most proxies will allow WebSocket connections with no additional configuration.

### Juju Events Changes

Modify `agent-relation-joined`

### Module Changes

Add observer for `agent-discovery-ingress`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
