### PR TITLE
Do not strip ingress prefix

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,3 +19,4 @@ jobs:
       juju-channel: 3.1/stable
       self-hosted-runner: true
       self-hosted-runner-label: "xlarge"
+      microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4"

--- a/src-docs/actions.py.md
+++ b/src-docs/actions.py.md
@@ -31,7 +31,7 @@ Initialize the observer and register actions handlers.
  
  - <b>`charm`</b>:  The parent charm to attach the observer to. 
  - <b>`state`</b>:  The Jenkins charm state. 
- - <b>`jenkins_instance`</b>:  The Jenkins wrapper. 
+ - <b>`jenkins_instance`</b>:  The Jenkins instance. 
 
 
 ---

--- a/src-docs/agent.py.md
+++ b/src-docs/agent.py.md
@@ -60,7 +60,7 @@ Initialize the observer and register event handlers.
  
  - <b>`charm`</b>:  The parent charm to attach the observer to. 
  - <b>`state`</b>:  The charm state. 
- - <b>`jenkins_instance`</b>:  The Jenkins wrapper. 
+ - <b>`jenkins_instance`</b>:  The Jenkins instance. 
  - <b>`ingress_observer`</b>:  The ingress observer responsible for agent discovery. 
 
 

--- a/src-docs/ingress.py.md
+++ b/src-docs/ingress.py.md
@@ -41,7 +41,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/ingress.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/ingress.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_path`
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -18,7 +18,7 @@ class Observer(ops.Object):
         Args:
             charm: The parent charm to attach the observer to.
             state: The Jenkins charm state.
-            jenkins_instance: The Jenkins wrapper.
+            jenkins_instance: The Jenkins instance.
         """
         super().__init__(charm, "actions-observer")
         self.charm = charm

--- a/src/agent.py
+++ b/src/agent.py
@@ -48,7 +48,7 @@ class Observer(ops.Object):
         Args:
             charm: The parent charm to attach the observer to.
             state: The charm state.
-            jenkins_instance: The Jenkins wrapper.
+            jenkins_instance: The Jenkins instance.
             ingress_observer: The ingress observer responsible for agent discovery.
         """
         super().__init__(charm, "agent-observer")

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -28,7 +28,6 @@ class Observer(ops.Object):
             self.charm,
             relation_name=relation_name,
             port=jenkins.WEB_PORT,
-            strip_prefix=True,
         )
 
     def get_path(self) -> str:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -777,7 +777,7 @@ def external_hostname_fixture() -> str:
 
 
 @pytest_asyncio.fixture(scope="module", name="traefik_application_and_unit_ip")
-async def traefik_application_fixture(model: Model, external_hostname: str):
+async def traefik_application_fixture(model: Model):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(
         "traefik-k8s",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -783,11 +783,7 @@ async def traefik_application_fixture(model: Model, external_hostname: str):
         "traefik-k8s",
         channel="edge",
         trust=True,
-        config={
-            "external_hostname": external_hostname,
-            "routing_mode": "path",
-            "enable_experimental_forward_auth": True,
-        },
+        config={"routing_mode": "path"},
     )
 
     await model.wait_for_idle(

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -21,7 +21,6 @@ async def test_ingress_integration(
     model: Model,
     application: Application,
     traefik_application_and_unit_ip: typing.Tuple[Application, str],
-    external_hostname: str,
 ):
     """
     arrange: deploy the Jenkins charm and establish relations via ingress.
@@ -35,7 +34,6 @@ async def test_ingress_integration(
     )
     response = requests.get(
         f"http://{traefik_address}/{model.name}-{application.name}",
-        headers={"Host": f"{external_hostname}"},
         timeout=5,
     )
 

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -57,7 +57,12 @@ async def test_agent_discovery_ingress_integration(
     machine_model = jenkins_machine_agents.model
     traefik_application, traefik_address = traefik_application_and_unit_ip
     # The jenkins prefix will be fetch from the main ingress, which is not related for this test
-    await traefik_application.set_config({"routing_mode": "subdomain"})
+    await traefik_application.set_config(
+        {
+            "routing_mode": "subdomain",
+            "external_hostname": external_hostname,
+        }
+    )
     await application.relate(
         AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"
     )

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -266,10 +266,10 @@ def test_version_error(
     assert: JenkinsError exception is raised.
     """
     monkeypatch.setattr(jenkins.requests, "get", MagicMock(side_effect=exception))
-    jenking_wrapper = jenkins.Jenkins(mock_env)
+    jenking_instance = jenkins.Jenkins(mock_env)
 
     with pytest.raises(jenkins.JenkinsError):
-        jenking_wrapper.version  # pylint: disable=pointless-statement
+        jenking_instance.version  # pylint: disable=pointless-statement
 
 
 def test_version(


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

<!-- A high level overview of the change -->
URL prefix doesn't need to be removed as it has to be present on the requests for integration with oathkeeper to work properly.
Also simplifies the integration tests and aligns them with oathkeeper requirements

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
ingress.py

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
