### PR TITLE
Set charm status to waiting if ingress is not ready or if the 2 ingresses have conflicting path

### DIFF
--- a/src-docs/ingress.py.md
+++ b/src-docs/ingress.py.md
@@ -56,4 +56,21 @@ Return the path in whick Jenkins is expected to be listening.
 **Returns:**
   the path for the ingress URL. 
 
+---
+
+<a href="../src/ingress.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `is_ingress_ready`
+
+```python
+is_ingress_ready() → str
+```
+
+Indicate if the ingress relation is ready. 
+
+
+
+**Returns:**
+  True if ingress is ready 
+
 

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -42,3 +42,11 @@ class Observer(ops.Object):
         if path == "/":
             return ""
         return path
+
+    def is_ingress_ready(self) -> str:
+        """Indicate if the ingress relation is ready.
+
+        Returns:
+            True if ingress is ready
+        """
+        return self.ingress.is_ready()


### PR DESCRIPTION


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
