### PR TITLE
ISD-1729 Add RAM percentage JVM option and documentations

### DIFF
--- a/docs/how-to/configure-jenkins-memory-usage.md
+++ b/docs/how-to/configure-jenkins-memory-usage.md
@@ -8,5 +8,6 @@ To change this value after deployment, use the `set-constraints` command.
 juju set-constraints jenkins-k8s "mem=4096M"
 ```
 Other types of constraints (like cores, disk, etc.) can also be applied. Note that this value affects the shared maximum memory between the `charm` container and `jenkins` container.
+
 # Considerations when applying memory constraints
 Constraints set this way directly influence the amount of heap memory available to the JVM, with a ratio `JVM heap / Container Memory limit` of 0.5. For example, a `jenkins-k8s-operator` charm deployed with `--constraints "mem=1024M"` would set a maximum heap memory size of 512Mb. Too little heap memory can result in the controller getting restarted due to Out-of-memory(OOM) error. Make sure to adapt the memory constraints based on your workload.

--- a/docs/how-to/configure-jenkins-memory-usage.md
+++ b/docs/how-to/configure-jenkins-memory-usage.md
@@ -1,0 +1,12 @@
+# How to control heap memory of the jenkins-k8s-operator charm
+The [jenkins-k8s-operator](https://github.com/canonical/jenkins-k8s-operator) charm uses [juju constraints](https://juju.is/docs/juju/constraint) to limit the amount of memory a charm can use. To deploy the charm with constraints, use the `--constraints "<key>=<value>"` option when running `juju deploy`:
+```bash
+juju deploy jenkins-k8s --channel=latest/edge --constraints "mem=2048M"
+```
+To change this value after deployment, use the `set-constraints` command
+```bash
+juju set-constraints jenkins-k8s "mem=4096M"
+```
+Other types of constraints (like cores, disk, etc.) can also be applied
+# Considerations when applying memory constraints
+Constraints set this way directly influence the amount of heap memory available to the JVM, with a ratio `JVM heap / Container Memory limit` of 0.5. For example, a `jenkins-k8s-operator` charm deployed with `--constraints "mem=1024M"` would set a maximum heap memory size of 512Mb. Too little heap memory can result in the controller getting restarted due to Out-of-memory(OOM) error. Make sure to adapt the memory constraints based on your workload.

--- a/docs/how-to/configure-jenkins-memory-usage.md
+++ b/docs/how-to/configure-jenkins-memory-usage.md
@@ -3,10 +3,10 @@ The [jenkins-k8s-operator](https://github.com/canonical/jenkins-k8s-operator) ch
 ```bash
 juju deploy jenkins-k8s --channel=latest/edge --constraints "mem=2048M"
 ```
-To change this value after deployment, use the `set-constraints` command
+To change this value after deployment, use the `set-constraints` command.
 ```bash
 juju set-constraints jenkins-k8s "mem=4096M"
 ```
-Other types of constraints (like cores, disk, etc.) can also be applied
+Other types of constraints (like cores, disk, etc.) can also be applied. Note that this value affects the shared maximum memory between the `charm` container and `jenkins` container.
 # Considerations when applying memory constraints
 Constraints set this way directly influence the amount of heap memory available to the JVM, with a ratio `JVM heap / Container Memory limit` of 0.5. For example, a `jenkins-k8s-operator` charm deployed with `--constraints "mem=1024M"` would set a maximum heap memory size of 512Mb. Too little heap memory can result in the controller getting restarted due to Out-of-memory(OOM) error. Make sure to adapt the memory constraints based on your workload.

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -78,8 +78,8 @@ def _get_pebble_layer(jenkins_instance: jenkins.Jenkins) -> ops.pebble.Layer:
                 "summary": "jenkins",
                 "command": f"java -D{jenkins.SYSTEM_PROPERTY_HEADLESS} "
                 f"-D{jenkins.SYSTEM_PROPERTY_LOGGING} "
-                f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
                 "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0 "
+                f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
                 f"--prefix={env_dict['JENKINS_PREFIX']}",
                 "startup": "enabled",
                 "environment": env_dict,

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -79,8 +79,8 @@ def _get_pebble_layer(jenkins_instance: jenkins.Jenkins) -> ops.pebble.Layer:
                 "command": f"java -D{jenkins.SYSTEM_PROPERTY_HEADLESS} "
                 f"-D{jenkins.SYSTEM_PROPERTY_LOGGING} "
                 f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
-                f"--prefix={env_dict['JENKINS_PREFIX']} "
-                "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0",
+                "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0 "
+                f"--prefix={env_dict['JENKINS_PREFIX']} ",
                 "startup": "enabled",
                 "environment": env_dict,
                 "user": jenkins.USER,

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -79,7 +79,7 @@ def _get_pebble_layer(jenkins_instance: jenkins.Jenkins) -> ops.pebble.Layer:
                 "command": f"java -D{jenkins.SYSTEM_PROPERTY_HEADLESS} "
                 f"-D{jenkins.SYSTEM_PROPERTY_LOGGING} "
                 f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
-                f"--prefix={env_dict['JENKINS_PREFIX']}"
+                f"--prefix={env_dict['JENKINS_PREFIX']} "
                 "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0",
                 "startup": "enabled",
                 "environment": env_dict,

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -75,7 +75,8 @@ def _get_pebble_layer(jenkins_instance: jenkins.Jenkins) -> ops.pebble.Layer:
                 "command": f"java -D{jenkins.SYSTEM_PROPERTY_HEADLESS} "
                 f"-D{jenkins.SYSTEM_PROPERTY_LOGGING} "
                 f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
-                f"--prefix={env_dict['JENKINS_PREFIX']}",
+                f"--prefix={env_dict['JENKINS_PREFIX']}"
+                "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0",
                 "startup": "enabled",
                 "environment": env_dict,
                 "user": jenkins.USER,

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -80,7 +80,7 @@ def _get_pebble_layer(jenkins_instance: jenkins.Jenkins) -> ops.pebble.Layer:
                 f"-D{jenkins.SYSTEM_PROPERTY_LOGGING} "
                 f"-jar {jenkins.EXECUTABLES_PATH}/jenkins.war "
                 "-XX:MaxRAMPercentage=50.0 -XX:InitialRAMPercentage=50.0 "
-                f"--prefix={env_dict['JENKINS_PREFIX']} ",
+                f"--prefix={env_dict['JENKINS_PREFIX']}",
                 "startup": "enabled",
                 "environment": env_dict,
                 "user": jenkins.USER,


### PR DESCRIPTION
based on https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/best-practices/jvm-memory-settings-best-practice

Following internal discussion, we have decided to add these JVM options when starting pebble to use together with juju constraints to manage the available memory for a jenkins-k8s charm.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
