### PR TITLE
pin resource rev due to instability

### DIFF
--- a/tests/integration/files/identity-bundle-edge-patched.yaml
+++ b/tests/integration/files/identity-bundle-edge-patched.yaml
@@ -30,6 +30,8 @@ applications:
     scale: 1
     series: jammy
     trust: true
+    resources:
+      oci-image: 79
   postgresql-k8s:
     charm: postgresql-k8s
     channel: 14/stable


### PR DESCRIPTION
New oci-image rev of the identity team's [login-ui-operator](https://charmhub.io/identity-platform-login-ui-operator/resources/oci-image) is breaking charm revision 79

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
