### PR TITLE
ISD-1846 Refresh agent relation on charm upgrade

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -97,7 +97,7 @@ Return a dictionary for Jenkins Pebble layer.
 
 ---
 
-<a href="../src/charm.py#L175"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `jenkins_set_storage_config`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -171,6 +171,9 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         container = self.unit.get_container(JENKINS_SERVICE_NAME)
         if not jenkins.is_storage_ready(container):
             self.jenkins_set_storage_config(event)
+        # Update the agent discovery address.
+        # Updating the secret is not required since it's calculated using the agent's node name.
+        self.agent_observer.reconfigure_agent_discovery(event)
 
     def jenkins_set_storage_config(self, event: ops.framework.EventBase) -> None:
         """Correctly set permissions when storage is attached.


### PR DESCRIPTION
During charm upgrade, when not using `agent-discovery-ingress`, the Pod IP address of the jenkins charm unit changes, leading to disconnection of agents. This PR adds `self.agent_observer.reconfigure_agent_discovery(event)` to the `_on_charm_upgrade` hook to update the discovery address in the relation databag. Note that since the secrets used by the agents are calculated based on the agent's node name, this value stays the same between charm upgrades.

### Checklist
- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
