### PR TITLE
Update location to jenkins logs so it's together with the others

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -32,7 +32,7 @@ _Interface_: loki_push_api
 _Supported charms_: [loki-k8s](https://charmhub.io/loki-k8s)
 
 Logging relation provides a way to scrape logs produced from the Jenkins server charm. The Jenkins 
-server logs are stored at `/var/lib/jenkins/jenkins.log`. These logs are the same logs as the logs 
+server logs are stored at `/var/lib/jenkins/logs/jenkins.log`. These logs are the same logs as the logs 
 emitted to the standard output. A promtail worker is spawned and will periodically push logs to
 Loki.
 

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -50,7 +50,7 @@ PLUGINS_PATH = JENKINS_HOME_PATH / "plugins"
 # The Jenkins logging configuration path
 LOGGING_CONFIG_PATH = JENKINS_HOME_PATH / "logging.properties"
 # The Jenkins logging path as defined in templates/logging.properties file
-LOGGING_PATH = JENKINS_HOME_PATH / "jenkins.log"
+LOGGING_PATH = JENKINS_HOME_PATH / "logs/jenkins.log"
 # The plugins that are required for Jenkins to work
 REQUIRED_PLUGINS = [
     "instance-identity",  # required to connect agent nodes to server

--- a/templates/logging.properties
+++ b/templates/logging.properties
@@ -32,7 +32,7 @@ handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 ############################################################
 
 # default file output is in user's home directory.
-java.util.logging.FileHandler.pattern = /var/lib/jenkins/jenkins.log
+java.util.logging.FileHandler.pattern = /var/lib/jenkins/logs/jenkins.log
 java.util.logging.FileHandler.limit = 50000
 java.util.logging.FileHandler.count = 1
 java.util.logging.FileHandler.append=true

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -88,7 +88,7 @@ async def test_loki_integration(
                 log_files_exist,
                 unit.address,
                 application.name,
-                ("/var/lib/jenkins/jenkins.log",),
+                ("/var/lib/jenkins/logs/jenkins.log",),
             ),
             timeout=10 * 60,
         )


### PR DESCRIPTION
### Overview

Move Jenkins log so it's under $JENKINS_HOME/logs along with other logs such as tasks, slaves/agents, health-checker, and sse-events.

### Rationale

Seems out of place with the other logs:

```
root@jenkins-k8s-0:/var/lib/jenkins# find logs -ls
   393217      4 drwxr-xr-x   5 jenkins  jenkins      4096 May  1 04:28 logs
   393226      4 drwxr-xr-x   2 jenkins  jenkins      4096 May  8 21:41 logs/tasks
   393225      4 -rw-r--r--   1 jenkins  jenkins      3195 May  8 01:59 logs/tasks/Periodic\ background\ build\ discarder.log.2
   430250      4 -rw-r--r--   1 jenkins  jenkins      1957 May  6 03:37 logs/tasks/Workspace\ clean-up.log.2
   420634      4 -rw-r--r--   1 jenkins  jenkins       107 May  1 04:23 logs/tasks/Fingerprint\ cleanup.log.5
   430243     76 -rw-r--r--   1 jenkins  jenkins     73463 May  9 02:27 logs/tasks/Periodic\ background\ build\ discarder.log
   430246      4 -rw-r--r--   1 jenkins  jenkins       107 May  1 20:46 logs/tasks/Fingerprint\ cleanup.log.4
   430248      4 -rw-r--r--   1 jenkins  jenkins       979 May  3 15:04 logs/tasks/Workspace\ clean-up.log.3
   393224     40 -rw-r--r--   1 jenkins  jenkins     38328 May  8 01:38 logs/tasks/Periodic\ background\ build\ discarder.log.3
   393221      4 -rw-r--r--   1 jenkins  jenkins       979 May  8 21:41 logs/tasks/Workspace\ clean-up.log
   393220      4 -rw-r--r--   1 jenkins  jenkins       107 May  8 17:04 logs/tasks/Fingerprint\ cleanup.log
   430245      4 -rw-r--r--   1 jenkins  jenkins      1960 May  2 11:24 logs/tasks/Workspace\ clean-up.log.4
   430252      4 -rw-r--r--   1 jenkins  jenkins       978 May  7 03:37 logs/tasks/Workspace\ clean-up.log.1
   430241      4 -rw-r--r--   1 jenkins  jenkins       215 May  4 05:27 logs/tasks/Fingerprint\ cleanup.log.3
   430244     84 -rw-r--r--   1 jenkins  jenkins     79851 May  6 12:38 logs/tasks/Periodic\ background\ build\ discarder.log.5
   430242      8 -rw-r--r--   1 jenkins  jenkins      6388 May  8 03:48 logs/tasks/Periodic\ background\ build\ discarder.log.1
   430249      4 -rw-r--r--   1 jenkins  jenkins       214 May  5 11:21 logs/tasks/Fingerprint\ cleanup.log.2
   430247     84 -rw-r--r--   1 jenkins  jenkins     79850 May  7 13:38 logs/tasks/Periodic\ background\ build\ discarder.log.4
   430251      4 -rw-r--r--   1 jenkins  jenkins       214 May  7 11:21 logs/tasks/Fingerprint\ cleanup.log.1
   393219      4 drwxr-xr-x   2 jenkins  jenkins      4096 May  8 05:21 logs/slaves
   393218      4 -rw-r--r--   1 jenkins  jenkins       487 May  9 03:09 logs/health-checker.log
   393223      4 drwxr-xr-x   2 jenkins  jenkins      4096 May  1 04:28 logs/sse-events
root@jenkins-k8s-0:/var/lib/jenkins#
```

### Juju Events Changes


### Module Changes


### Library Changes


### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)