### PR TITLE
Fix typo in docstrings

### DIFF
--- a/src-docs/ingress.py.md
+++ b/src-docs/ingress.py.md
@@ -49,7 +49,7 @@ Shortcut for more simple access the model.
 get_path() → str
 ```
 
-Return the path in whick Jenkins is expected to be listening. 
+Return the path in which Jenkins is expected to be listening. 
 
 
 

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -31,7 +31,7 @@ class Observer(ops.Object):
         )
 
     def get_path(self) -> str:
-        """Return the path in whick Jenkins is expected to be listening.
+        """Return the path in which Jenkins is expected to be listening.
 
         Returns:
             the path for the ingress URL.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix a typo

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
