### PR TITLE
[WIP] test: add test for juju 2.9

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       self-hosted-runner-label: "xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
 
-  integration-tests2.9:
+  integration-tests-juju-29:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       self-hosted-runner-label: "xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
 
-  integration-tests-2.9:
+  integration-tests2.9:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,6 +16,7 @@ jobs:
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
         chmod +x tests/integration/pre_run_script.sh
         ./tests/integration/pre_run_script.sh"
+      test-tox-env: integration-juju3.1
       juju-channel: 3.1/stable
       self-hosted-runner: true
       self-hosted-runner-label: "xlarge"
@@ -33,6 +34,7 @@ jobs:
         -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
         chmod +x tests/integration/pre_run_script.sh
         ./tests/integration/pre_run_script.sh"
+      test-tox-env: integration-juju2.9
       juju-channel: 2.9/stable
       self-hosted-runner: true
       self-hosted-runner-label: "xlarge"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,3 +20,20 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-label: "xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+
+  integration-tests-2.9:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      channel: 1.28-strict/stable
+      extra-arguments: |
+        --kube-config=${GITHUB_WORKSPACE}/kube-config
+      modules: '["test_auth_proxy.py", "test_cos.py", "test_ingress.py", "test_jenkins.py", "test_k8s_agent.py", "test_machine_agent.py", "test_plugins.py", "test_proxy.py", "test_upgrade.py", "test_external_agent.py"]'
+      pre-run-script: |
+        -c "sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
+        chmod +x tests/integration/pre_run_script.sh
+        ./tests/integration/pre_run_script.sh"
+      juju-channel: 2.9/stable
+      self-hosted-runner: true
+      self-hosted-runner-label: "xlarge"
+      microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # charm artifact
 *.charm
+
+# Development artifacdts
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./lib"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python.analysis.extraPaths": [
-        "./lib"
-    ]
-}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 name: jenkins-k8s
 assumes:
   - k8s-api
+  - juju >= 2.9
 display-name: Jenkins K8s
 summary: Jenkins Continuous Integration Server
 maintainers:

--- a/tox.ini
+++ b/tox.ini
@@ -110,17 +110,17 @@ deps =
 commands =
     coverage report
 
-[testenv:integration]
+[testenv:integration-juju{3.2,3.1,2.9}]
 description = Run integration tests
 deps =
     pytest
-    juju>=3,<3.5
-    macaroonbakery==1.3.2 # temporary bug with libjuju
+    juju3.2: juju==3.2.*
+    juju3.1: juju==3.1.*
+    juju2.9: juju==2.9.*
     ops
     pytest-operator
     pytest-asyncio
-    # Type error problem with newer version of macaroonbakery
-    macaroonbakery==1.3.2
+    macaroonbakery
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}integration/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju>=3,<4
+    juju>=3,<3.5
     macaroonbakery==1.3.2 # temporary bug with libjuju
     ops
     pytest-operator


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add integration test for Juju 2.9

### Rationale

Jenkins instances require 2.9 support for PS5 deployments.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
