### PR TITLE
fix: build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,13 +4,10 @@
 type: charm
 parts:
   charm:
+    build-snaps:
+      - rustup
     override-build: |
-      # install latest version of rust deps because rust-all rustc 1.76 or greater is required to
-      # build requests lib from source.
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      mv $HOME/.cargo/bin/* /usr/bin/
-      # setuptools >= 61 is required
-      pip install --upgrade setuptools
+      rustup default stable
       craftctl default
     prime:
       - templates/jenkins-auth-proxy-config.xml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,7 +5,9 @@ type: charm
 parts:
   charm:
     build-packages:
-      - rust-all  # for cryptography
+      # for building requests dependency in rust
+      - libssl-dev
+      - rust-all
     prime:
       - templates/jenkins-auth-proxy-config.xml
       - templates/jenkins-config.xml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,10 +4,14 @@
 type: charm
 parts:
   charm:
-    build-packages:
-      # for building requests dependency in rust
-      - libssl-dev
-      - rust-all
+    override-build: |
+      # install latest version of rust deps because rust-all rustc 1.76 or greater is required to
+      # build requests lib from source.
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      mv $HOME/.cargo/bin/* /usr/bin/
+      # setuptools >= 61 is required
+      pip install --upgrade setuptools
+      craftctl default
     prime:
       - templates/jenkins-auth-proxy-config.xml
       - templates/jenkins-config.xml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,8 @@ parts:
     override-build: |
       rustup default stable
       craftctl default
+    charm-binary-python-packages:
+      - setuptools
     prime:
       - templates/jenkins-auth-proxy-config.xml
       - templates/jenkins-config.xml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,14 @@
 # See LICENSE file for licensing details.
 
 type: charm
+parts:
+  charm:
+    build-packages:
+      - rust-all  # for cryptography
+    prime:
+      - templates/jenkins-auth-proxy-config.xml
+      - templates/jenkins-config.xml
+      - templates/logging.properties
 bases:
   - build-on:
     - name: ubuntu

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ def pytest_addoption(parser: pytest.Parser):
     Args:
         parser: pytest command line parser.
     """
+    print("hello world")
     # The prebuilt charm file.
     parser.addoption("--charm-file", action="append", default=[])
     # The Jenkins image name:tag.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ def pytest_addoption(parser: pytest.Parser):
     Args:
         parser: pytest command line parser.
     """
-    print("hello world")
     # The prebuilt charm file.
     parser.addoption("--charm-file", action="append", default=[])
     # The Jenkins image name:tag.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Fix broken dependency chain build (rpds-py) by building rustc ourselves. (build-package `rust-all` version 1.75 is not supported by rpds-py)

### Rationale

- To build the charm.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
