### PR TITLE
revert setuptools breaking dep issue (fixed upstream)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,8 +9,6 @@ parts:
     override-build: |
       rustup default stable
       craftctl default
-    charm-binary-python-packages:
-      - setuptools
     prime:
       - templates/jenkins-auth-proxy-config.xml
       - templates/jenkins-config.xml


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fixed upstream: https://github.com/pypa/setuptools/commit/441799f8b45a1a01c608db49333403db1b0d7100#diff-61d113525e9cc93565799a4bb8b34a68e2945b8a3f7d90c81380614a4ea39542R7

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
