### PR TITLE
Update Jenkins to 2.492.1

### DIFF
--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -58,7 +58,7 @@ parts:
       - wget
       - unzip
     build-environment:
-      - JENKINS_VERSION: 2.479.2
+      - JENKINS_VERSION: 2.492.1
       - JENKINS_PLUGIN_MANAGER_VERSION: 2.13.2
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/{srv/jenkins/,etc/default/jenkins/}


### PR DESCRIPTION
### Overview

Upgrade Jenkins to [2.492.1](https://www.jenkins.io/changelog/2.492.1/)

### Rationale

To keep up to date with the LTS version

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
