### PR TITLE
Bump Jenkins to 2.492.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The focus of Jenkins is the building/testing of software projects continuously, 
 executions of externally-run jobs. More information at http://jenkins-ci.org/.
 
 This charm provides the Jenkins server service, and when paired with the
-jenkins agent provides an easy way to deploy Jenkins.
+jenkins agent, provides an easy way to deploy Jenkins.
 
 For DevOps and SRE teams, this charm will make operating Jenkins simple and straightforward
 through Juju's clean interface. Allowing both kubernetes and machine agent relations, it supports

--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -58,7 +58,7 @@ parts:
       - wget
       - unzip
     build-environment:
-      - JENKINS_VERSION: 2.492.1
+      - JENKINS_VERSION: 2.492.2
       - JENKINS_PLUGIN_MANAGER_VERSION: 2.13.2
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/{srv/jenkins/,etc/default/jenkins/}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Bumps Jenkins to 2.492.2

### Rationale

To keep up with the latest LTS

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
