### PR TITLE
fix: fix the auth test by bumping login ui revision

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -783,8 +783,7 @@ async def oathkeeper_application_related_fixture(
     oathkeeper = await model.deploy("oathkeeper", channel="edge", trust=True)
     kratos_app = await model.deploy(
         "kratos",
-        channel="latest/stable",
-        revision=527,
+        channel="0.4/edge",
         # Needed per https://github.com/canonical/oathkeeper-operator/issues/49
         config={"dev": "True"},
         trust=True,
@@ -830,7 +829,7 @@ async def oathkeeper_application_related_fixture(
     )
     login_ui_app = await model.deploy(
         "identity-platform-login-ui-operator",
-        channel="0.3/edge",
+        channel="latest/edge",
         trust=True,
     )
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This pull request aims to fix the [issue](https://github.com/canonical/kratos-operator/issues/386) by bumping the identity-platform-login-ui-operator charm's version. The failure is due to a recent `ui-endpoint-info` library update.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
