### PR TITLE
feat: add LTS jenkins renovate

### DIFF
--- a/jenkins_rock/rockcraft.yaml
+++ b/jenkins_rock/rockcraft.yaml
@@ -20,7 +20,7 @@ services:
       JENKINS_HOME: /var/lib/jenkins
     user: jenkins
     group: jenkins
-    
+
 parts:
   add-user:
     plugin: nil
@@ -58,6 +58,8 @@ parts:
       - wget
       - unzip
     build-environment:
+      # Modifying the following format will break renovate configuration for auto-patching Jenkins.
+      # See renovate.json "customManagers" section.
       - JENKINS_VERSION: 2.492.3
       - JENKINS_PLUGIN_MANAGER_VERSION: 2.13.2
     override-build: |

--- a/renovate.json
+++ b/renovate.json
@@ -5,15 +5,39 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["(^|/)rockcraft.yaml$"],
+      "fileMatch": [
+        "(^|/)rockcraft.yaml$"
+      ],
       "description": "Update base image references",
       "matchStringsStrategy": "any",
-      "matchStrings": ["# renovate: build-base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
-      "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"],
+      "matchStrings": [
+        "# renovate: build-base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
+        "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"
+      ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "ubuntu"
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)rockcraft\\.yaml$/"
+      ],
+      "matchStrings": [
+        "JENKINS_VERSION: (?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "jenkins",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.jenkins"
+    }
+  ],
+  "customDatasources": {
+    "jenkins": {
+      "defaultRegistryUrlTemplate": "https://www.jenkins.io/changelog-stable/",
+      "format": "html"
+    }
+  },
   "packageRules": [
     {
       "enabled": true,
@@ -23,9 +47,21 @@
       "pinDigests": true
     },
     {
-      "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchFiles": [
+        "rockcraft.yaml"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
       "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "custom.jenkins"
+      ],
+      "extractVersion": "/changelog\/(?<version>.+)\/$"
     }
   ]
 }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Adds renovate to Jenkins LTS version patches

<!-- A high level overview of the change -->

### Rationale

- To automatically issue patches whenever Jenkins is ready
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

This is not a user facing change but rather a change to the CI/CD for renovate.
<!-- Explanation for any unchecked items above -->
