### PR TITLE
fix: agent connectivity on server ingress relation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-09-05
+
+- Fix issue with Jenkins agent node server discovery when ingress is applied to server
+
 ### 2025-09-02
 
 - Upgrade Jenkins version to latest LTS (v2.516.2)

--- a/src/agent.py
+++ b/src/agent.py
@@ -13,11 +13,16 @@ from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerApp
 
 import ingress
 import jenkins
-from state import AGENT_RELATION, DEPRECATED_AGENT_RELATION, JENKINS_SERVICE_NAME, AgentMeta, State
+from state import (
+    AGENT_DISCOVERY_INGRESS_RELATION_NAME,
+    AGENT_RELATION,
+    DEPRECATED_AGENT_RELATION,
+    JENKINS_SERVICE_NAME,
+    AgentMeta,
+    State,
+)
 
 logger = logging.getLogger(__name__)
-
-AGENT_DISCOVERY_INGRESS_RELATION_NAME = "agent-discovery-ingress"
 
 
 @dataclass(frozen=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ import jenkins
 import pebble
 import timerange
 from state import (
+    INGRESS_RELATION_NAME,
     JENKINS_SERVICE_NAME,
     CharmConfigInvalidError,
     CharmIllegalNumUnitsError,
@@ -28,7 +29,6 @@ from state import (
     State,
 )
 
-INGRESS_RELATION_NAME = "ingress"
 logger = logging.getLogger(__name__)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,11 +61,12 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         self.jenkins = jenkins.Jenkins(self.calculate_env())
         self.actions_observer = actions.Observer(self, self.state, self.jenkins)
         self.agent_observer = agent.Observer(
-            self,
-            self.state,
-            self.agent_discovery_ingress_observer,
-            self.ingress_observer,
-            self.jenkins,
+            charm=self,
+            state=self.state,
+            observers=agent.IngressObservers(
+                agent_discovery=self.agent_discovery_ingress_observer, server=self.ingress_observer
+            ),
+            jenkins_instance=self.jenkins,
         )
         self.cos_observer = cos.Observer(self)
         self.auth_proxy_observer = auth_proxy.Observer(

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,7 +62,11 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         self.jenkins = jenkins.Jenkins(self.calculate_env())
         self.actions_observer = actions.Observer(self, self.state, self.jenkins)
         self.agent_observer = agent.Observer(
-            self, self.state, self.agent_discovery_ingress_observer, self.jenkins
+            self,
+            self.state,
+            self.agent_discovery_ingress_observer,
+            self.ingress_observer,
+            self.jenkins,
         )
         self.cos_observer = cos.Observer(self)
         self.auth_proxy_observer = auth_proxy.Observer(

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,6 @@ from state import (
     State,
 )
 
-AGENT_DISCOVERY_INGRESS_RELATION_NAME = "agent-discovery-ingress"
 INGRESS_RELATION_NAME = "ingress"
 logger = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
 
         # Ingress dedicated to agent discovery
         self.agent_discovery_ingress_observer = ingress.Observer(
-            self, "agent-discovery-ingress-observer", AGENT_DISCOVERY_INGRESS_RELATION_NAME
+            self, "agent-discovery-ingress-observer", agent.AGENT_DISCOVERY_INGRESS_RELATION_NAME
         )
         self.ingress_observer = ingress.Observer(self, "ingress-observer", INGRESS_RELATION_NAME)
         self.jenkins = jenkins.Jenkins(self.calculate_env())

--- a/src/state.py
+++ b/src/state.py
@@ -20,6 +20,8 @@ DEPRECATED_AGENT_RELATION = "agent-deprecated"
 AUTH_PROXY_RELATION = "auth-proxy"
 JENKINS_SERVICE_NAME = "jenkins"
 JENKINS_HOME_STORAGE_NAME = "jenkins-home"
+INGRESS_RELATION_NAME = "ingress"
+AGENT_DISCOVERY_INGRESS_RELATION_NAME = "agent-discovery-ingress"
 
 
 class CharmStateBaseError(Exception):
@@ -307,6 +309,13 @@ class State:
         if charm.app.planned_units() > 1:
             raise CharmIllegalNumUnitsError(
                 "The Jenkins charm supports only 1 unit of deployment."
+            )
+        agent_discovery_ingress = charm.model.get_relation(AGENT_DISCOVERY_INGRESS_RELATION_NAME)
+        server_ingress = charm.model.get_relation(INGRESS_RELATION_NAME)
+        if agent_discovery_ingress and not server_ingress:
+            raise CharmConfigInvalidError(
+                f"{INGRESS_RELATION_NAME} integration is required when using "
+                f"{AGENT_DISCOVERY_INGRESS_RELATION_NAME}"
             )
 
         return cls(

--- a/tests/integration/test_external_agent.py
+++ b/tests/integration/test_external_agent.py
@@ -6,46 +6,68 @@
 import typing
 
 import pytest
+import pytest_asyncio
 from juju.application import Application
+from juju.model import Model
 
 import state
-from agent import AGENT_DISCOVERY_INGRESS_RELATION_NAME
+
+from .helpers import get_model_unit_addresses
+
+
+@pytest_asyncio.fixture(scope="module", name="agent_discovery_traefik")
+async def agent_discovery_traefik_fixture(model: Model):
+    """The application related to Jenkins via ingress v2 relation."""
+    traefik = await model.deploy(
+        "traefik-k8s", channel="edge", trust=True, config={"routing_mode": "path"}
+    )
+    await model.wait_for_idle(
+        status="active", apps=[traefik.name], timeout=20 * 60, idle_period=30, raise_on_error=False
+    )
+    unit_ips = await get_model_unit_addresses(model=model, app_name=traefik.name)
+    assert unit_ips, f"Unit IP address not found for {traefik.name}"
+    return (traefik, unit_ips[0])
+
+
+@pytest_asyncio.fixture(scope="module", name="server_traefik")
+async def server_traefik_fixture(model: Model):
+    """The application related to Jenkins via ingress v2 relation."""
+    traefik = await model.deploy(
+        "traefik-k8s", channel="edge", trust=True, config={"routing_mode": "path"}
+    )
+    await model.wait_for_idle(
+        status="active", apps=[traefik.name], timeout=20 * 60, idle_period=30, raise_on_error=False
+    )
+    unit_ips = await get_model_unit_addresses(model=model, app_name=traefik.name)
+    assert unit_ips, f"Unit IP address not found for {traefik.name}"
+    return (traefik, unit_ips[0])
 
 
 # This will only work on microk8s !!
 @pytest.mark.abort_on_fail
 async def test_agent_discovery_ingress_integration(
     application: Application,
-    traefik_application_and_unit_ip: typing.Tuple[Application, str],
-    external_hostname: str,
+    agent_discovery_traefik: typing.Tuple[Application, str],
+    server_traefik: typing.Tuple[Application, str],
     jenkins_machine_agents: Application,
 ):
     """
     arrange: deploy the Jenkins charm, ingress, and a machine agent.
-    act: integrate the charms with each other and update the machine agent's dns record.
+    act: integrate the charms with each other.
     assert: All units should be in active status.
     """
     model = application.model
     machine_model = jenkins_machine_agents.model
-    traefik_application, traefik_address = traefik_application_and_unit_ip
-    # The jenkins prefix will be fetch from the main ingress, which is not related for this test
-    await traefik_application.set_config(
-        {
-            "routing_mode": "subdomain",
-            "external_hostname": external_hostname,
-        }
+    agent_discovery_traefik_application, _ = server_traefik
+    server_ingress_traefik_application, _ = agent_discovery_traefik
+
+    await application.relate(
+        state.AGENT_DISCOVERY_INGRESS_RELATION_NAME,
+        f"{agent_discovery_traefik_application.name}:ingress",
     )
     await application.relate(
-        AGENT_DISCOVERY_INGRESS_RELATION_NAME, f"{traefik_application.name}:ingress"
+        state.INGRESS_RELATION_NAME, f"{server_ingress_traefik_application.name}:ingress"
     )
-    # Add dns record
-    ingress_hostname_mapping = (
-        f"{traefik_address} {model.name}-{application.name}.{external_hostname}"
-    )
-    command = f"sudo echo '{ingress_hostname_mapping}' >> /etc/hosts"
-    for unit in jenkins_machine_agents.units:
-        action = await unit.run(command)
-        await action.wait()
 
     await model.relate(
         f"{application.name}:{state.AGENT_RELATION}",

--- a/tests/integration/test_external_agent.py
+++ b/tests/integration/test_external_agent.py
@@ -9,7 +9,7 @@ import pytest
 from juju.application import Application
 
 import state
-from charm import AGENT_DISCOVERY_INGRESS_RELATION_NAME
+from agent import AGENT_DISCOVERY_INGRESS_RELATION_NAME
 
 
 # This will only work on microk8s !!

--- a/tests/integration/test_external_agent.py
+++ b/tests/integration/test_external_agent.py
@@ -19,7 +19,11 @@ from .helpers import get_model_unit_addresses
 async def agent_discovery_traefik_fixture(model: Model):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(
-        "traefik-k8s", channel="edge", trust=True, config={"routing_mode": "path"}
+        "traefik-k8s",
+        channel="edge",
+        trust=True,
+        config={"routing_mode": "path"},
+        application_name="agent_discovery_traefik",
     )
     await model.wait_for_idle(
         status="active", apps=[traefik.name], timeout=20 * 60, idle_period=30, raise_on_error=False
@@ -33,7 +37,11 @@ async def agent_discovery_traefik_fixture(model: Model):
 async def server_traefik_fixture(model: Model):
     """The application related to Jenkins via ingress v2 relation."""
     traefik = await model.deploy(
-        "traefik-k8s", channel="edge", trust=True, config={"routing_mode": "path"}
+        "traefik-k8s",
+        channel="edge",
+        trust=True,
+        config={"routing_mode": "path"},
+        application_name="server_traefik",
     )
     await model.wait_for_idle(
         status="active", apps=[traefik.name], timeout=20 * 60, idle_period=30, raise_on_error=False

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -362,6 +362,26 @@ def test_agent_discovery_url_with_ingress(harness: Harness):
     assert harness.charm.agent_observer.agent_discovery_url == mock_ingress_url
 
 
+def test_agent_discovery_url_with_server_ingress(harness: Harness):
+    """
+    arrange: given a base jenkins charm with server ingress integration.
+    act: start the charm and add an server ingress integration with traefik.
+    assert: charm.agent_observer.agent_discovery_url is the value
+    from the ingress integration databag.
+    """
+    harness.begin()
+
+    mock_ingress_url = "http://ingress.test"
+    harness.add_relation(
+        "ingress",
+        "traefik-k8s",
+        app_data={"ingress": json.dumps({"url": mock_ingress_url})},
+    )
+
+    assert harness.charm.agent_observer.agent_discovery_url == mock_ingress_url
+    assert "Consider separating ingress for agents" in harness.charm.agent_observer._status_message
+
+
 def test_agent_discovery_url_fqdn_fallback(harness: Harness, monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a base jenkins charm with no ingress and an invalid ip.

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -513,7 +513,7 @@ def test_reconfigure_agent_discovery_url_ingress_revoked(
     """
     mock_ingress_url = "http://ingress.test"
     ingress_relation_id = harness.add_relation(
-        "agent-discovery-ingress",
+        "ingress",
         "traefik-k8s",
         app_data={"ingress": json.dumps({"url": mock_ingress_url})},
     )

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -184,6 +184,20 @@ def test_auth_proxy_integrated_true(mock_charm: MagicMock):
     assert not config.auth_proxy_integrated
 
 
+def test_agent_discovery_ingress_without_server_ingress(mock_charm: MagicMock):
+    """
+    arrange: a charm with agent discovery ingress but no server ingress.
+    act: when state.from_charm is called.
+    assert: CharmConfigInvalidError is raised.
+    """
+    mock_charm.model.get_relation = lambda relation_name: (
+        None if relation_name == state.INGRESS_RELATION_NAME else MagicMock()
+    )
+
+    with pytest.raises(state.CharmConfigInvalidError):
+        state.State.from_charm(mock_charm)
+
+
 def test_invalid_num_units(mock_charm: MagicMock):
     """
     arrange: given a mock charm with more than 1 unit of deployment.


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

- Fixes issue: https://github.com/canonical/jenkins-k8s-operator/issues/194
<!-- A high level overview of the change -->

### Rationale

- The Jenkins server URL is configured when ingress is available. This makes the agent nodes lose connection to the server since the server URL has been updated. This PR fixes such behavior.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
