### PR TITLE
feat(docs): Evolve and standardize the documentation workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,12 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  docs-checks:
+    uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit
+

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,16 @@ dmypy.json
 
 # charm artifact
 *.charm
+
+# BEGIN VALE WORKFLOW IGNORE
+.vale/styles/*
+!.vale/styles/local
+!.vale/styles/config/
+
+.vale/styles/config/*
+!.vale/styles/config/vocabularies/
+
+.vale/styles/config/vocabularies/*
+!.vale/styles/config/vocabularies/local
+# END VALE WORKFLOW IGNORE
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,12 @@
+; Copyright 2025 Canonical Ltd.
+; See LICENSE file for licensing details.
+
+StylesPath = .vale/styles
+
+Packages = https://github.com/canonical/platform-engineering-vale-package/releases/download/latest/pfe-vale.zip
+
+Vocab = PFE, local
+
+[*]
+BasedOnStyles = PFE
+

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Top-level Makefile
+# Delegates targets to Makefile.docs
+
+# ==============================================================================
+# Macros
+# ==============================================================================
+
+# Colors
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+# ==============================================================================
+# Core
+# ==============================================================================
+
+include Makefile.docs
+
+.PHONY: help 
+help: _list-targets ## Prints all available targets
+
+.PHONY: _list-targets
+_list-targets: ## This collects and prints all targets, ignore internal commands
+	$(call msg,Available targets:)
+	@awk -F'[:#]' '                                               \
+		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
+			target = $$1;                                         \
+			comment = "";                                         \
+			if (match($$0, /## .*/))                              \
+				comment = substr($$0, RSTART + 3);                \
+			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
+				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
+		}' $(MAKEFILE_LIST) | sort
+

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Minimal makefile for documentation
+#
+
+# Vale settings
+VALE_DIR ?= .vale
+PRAECEPTA_CONFIG 	?= .vale.ini
+DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+
+HAS_VALE			:= $(shell command -v vale;)
+HAS_LYCHEE			:= $(shell command -v lychee;)
+
+# ==============================================================================
+# Docs Targets
+# ==============================================================================
+
+.PHONY: docs-check
+docs-check: vale lychee ## Run all Docs checks
+
+.PHONY: docs-clean
+docs-clean: vale-clean
+
+# ==============================================================================
+# Dependency Check Targets
+# ==============================================================================
+
+.PHONY: .check-vale
+.check-vale:
+ifndef HAS_VALE
+	$(call errmsg,'vale' is not installed. Please install it first) \
+	exit 1;
+endif
+
+.PHONY: .check-lychee
+.check-lychee:
+ifndef HAS_LYCHEE
+	$(call errmsg,'lychee' is not installed. Please install it first) \
+	exit 1;
+endif
+
+
+# ==============================================================================
+# Main Vale Targets
+# ==============================================================================
+
+.PHONY: vale-sync
+vale-sync: ## Download and install external Vale configuration sources
+	$(call msg,--- Syncing Vale styles... ---)
+	@vale sync
+
+.PHONY: vale
+vale: .check-vale vale-sync ## Run Vale checks on docs
+	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
+
+# ==============================================================================
+# Main Lychee Targets
+# ==============================================================================
+
+.PHONY: lychee
+lychee: .check-lychee ## Run Lychee checks on docs
+	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@lychee $(DOCS_FILES)
+
+# ==============================================================================
+# Helper Targets
+# ==============================================================================
+
+.PHONY: vale-clean
+vale-clean:
+	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+	@git clean -dfX $(VALE_DIR)
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Promote charm](https://github.com/canonical/jenkins-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/jenkins-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators)
+A [Juju](https://juju.is/) [charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/)
 deploying and managing [Jenkins](https://jenkins.io/) on Kubernetes. Jenkins is an open source
 automation server, providing plugins to support building, deploying and automating any project.
 
@@ -28,11 +28,11 @@ To begin, refer to the [tutorial](https://charmhub.io/jenkins-k8s/docs/tutorial-
 
 ### Basic operations
 
-#### Expose jenkins-k8s through ingress
+#### Expose `jenkins-k8s` through ingress
 
 See the [Expose jenkins-k8s through ingress](https://charmhub.io/jenkins-k8s/docs/tutorial-getting-started#expose-jenkins-k8s-through-ingress) section in the jenkins-k8s-operator documentation.
 
-#### Integrate with the jenkins-agent and the jenkins-agent-k8s charm
+#### Integrate with the `jenkins-agent` and the `jenkins-agent-k8s` charms
 
 See the [deploy and integrate k8s agents](https://charmhub.io/jenkins-k8s/docs/tutorial-getting-started#deploy-and-integrate-k8s-agents) section and the [deploy and integrate machine agents](https://charmhub.io/jenkins-k8s/docs/tutorial-getting-started#deploy-and-integrate-machine-agents-optional) section in the jenkins-k8s-operator documentation.
 

--- a/docs/how-to/configure-jenkins-memory-usage.md
+++ b/docs/how-to/configure-jenkins-memory-usage.md
@@ -1,4 +1,4 @@
-# How to control heap memory of the jenkins-k8s-operator charm
+# How to control heap memory
 The [jenkins-k8s-operator](https://github.com/canonical/jenkins-k8s-operator) charm uses [Juju constraints](https://juju.is/docs/juju/constraint) to limit the amount of memory a charm can use. To deploy the charm with constraints, use the `--constraints "<key>=<value>"` option when running `juju deploy`:
 ```bash
 juju deploy jenkins-k8s --channel=latest/edge --constraints "mem=2048M"

--- a/docs/how-to/integrate-with-machine-agents.md
+++ b/docs/how-to/integrate-with-machine-agents.md
@@ -6,7 +6,7 @@ This guide assumes the `jenkins-k8s` charm to already be deployed on a k8s juju 
 
 To integrate machine (VM) agents, you'll need to have a bootstrapped machine model. Learn about
 bootstrapping different clouds
-[here](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
+[here](https://documentation.ubuntu.com/juju/3.6/tutorial/#prepare-your-cloud).
 
 Use `juju bootstrap localhost localhost` to bootstrap a `lxd` machine controller with the name
 `localhost` for tutorial purposes.
@@ -27,8 +27,8 @@ juju deploy jenkins-agent --channel=latest/edge -n3
 ### Create an offer for cross model relation
 
 To relate charms
-[across different models](https://juju.is/docs/juju/manage-cross-model-integrations), a juju
-[`offer`](https://juju.is/docs/juju/manage-cross-model-integrations#heading--create-an-offer) is
+[across different models](https://documentation.ubuntu.com/juju/3.6/howto/manage-relations/#add-a-cross-model-relation), a Juju
+[`offer`](https://documentation.ubuntu.com/juju/3.6/howto/manage-offers/#integrate-with-an-offer) is
 required.
 
 Create an offer of the `jenkins-agent` charm's `agent` relation.

--- a/docs/how-to/resize-jenkins-storage.md
+++ b/docs/how-to/resize-jenkins-storage.md
@@ -1,4 +1,4 @@
-# How to resize the jenkins-home storage volume
+# How to resize the Jenkins home storage volume
 The default size of the jenkins-home storage volume for a fresh installation is 1GB. While this works for most scenarios, operators might need to have more storage for installing plugins, storing artifacts, and running builds/checking out SCMs on the built-in node.
 
 A low disk-space on the built-in node will cause the node to go offline, blocking Jenkins from running jobs.

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -14,7 +14,7 @@ Example agent integrate command:
 juju relate jenkins-k8s:agent jenkins-agent-k8s:agent
 ```
 
-To create a [cross model relation](https://juju.is/docs/olm/manage-cross-model-integrations) with
+To create a [cross model relation](https://documentation.ubuntu.com/juju/3.6/howto/manage-relations/#add-a-cross-model-relation) with
 a jenkins-agent (VM) charm, create an offer from the machine model.
 
 ```
@@ -29,7 +29,7 @@ juju integrate jenkins-k8s:agent <controller-name>:<juju-user>/<agent-model>.jen
 
 An example of such command would look like the following, using a jenkins-agent deployed on a
 localhost
-[lxd controller](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
+[LXD controller](https://documentation.ubuntu.com/juju/3.6/tutorial/#prepare-your-cloud).
 
 ```
 juju integrate jenkins-k8s:agent localhost:admin/jenkins-vm-model.jenkins-agent

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,4 +1,4 @@
-# Deploy the jenkins-k8s charm for the first time
+# Deploy the `jenkins-k8s` charm for the first time
 
 ## What you'll do
 
@@ -12,13 +12,13 @@ tutorial will walk through each step of deployment to get a basic Jenkins server
 
 ### Requirements
 
-- A machine with amd64 architecture.
+- A machine with AMD64 architecture.
 - Juju 3 installed.
 - Juju MicroK8s controller created and active named `microk8s`. [MetalLB add-on](https://microk8s.io/docs/addon-metallb) should be enabled for traefik-k8s to work.
 - LXD controller created and active named `lxd` (optional).
-- All the requirements can be met using the [Multipass charm-dev blueprint](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#heading--set-up---tear-down-automatically). Use the Multipass VM shell to run all commands in this tutorial.
+- All the requirements can be met using the [Set up your deployment - local testing and development](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/). Use the Multipass VM shell to run all commands in this tutorial.
 
-For more information about how to install Juju, see [Get started with Juju](https://juju.is/docs/olm/get-started-with-juju).
+For more information about how to install Juju, see [Get started with Juju](https://documentation.ubuntu.com/juju/3.6/tutorial/).
 
 ### Set up the tutorial model
 
@@ -30,7 +30,7 @@ juju switch microk8s
 juju add-model jenkins-tutorial
 ```
 
-### Deploy the jenkins-k8s charm
+### Deploy the `jenkins-k8s` charm
 
 Start off by deploying the jenkins-k8s charm. By default it will deploy the latest stable release
 of the jenkins-k8s charm.
@@ -48,7 +48,7 @@ The Jenkins application can only have a single server unit. Adding more units th
 parameter will cause the application to misbehave.
 
 
-### Expose jenkins-k8s through ingress
+### Expose `jenkins-k8s` through ingress
 
 Deploy traefik-k8s charm and integrate it with the jenkins-k8s charm:
 ```


### PR DESCRIPTION
Applicable ticket: ISD-3255

### Description:

This PR builds upon our team's commitment to high-quality documentation by formalizing and standardizing our style-checking workflow.

It evolves our existing efforts of checking against the Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`) into a fully integrated, **`vale-native`** process. This more streamlined approach unlocks powerful new capabilities for the team, including:
* Seamless integration with the official **Vale GitHub Action** for automated checks via a new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml)
* Simple and consistent **`make` targets** for reliable local validation, in line with CI validation.
* The ability to use **IDE extensions** for real-time feedback while writing.

---
### Key Changes

* **CI Automation:**
    * Leveraging our new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml) to run on every pull request to:
        * Lint all documentation using **Vale**.
        * Check for **broken links**.

* **Layered Vale Configuration:**
    * **Project-Level:** A local `.vale.ini` and `accept.txt` allow for project-specific vocabulary and rule overrides.
    * **Team-Level:** The configuration inherits from our new central [platform-engineering-vale](https://github.com/canonical/platform-engineering-vale-package) package, allowing us to manage team-wide vocabulary and rules in one place.
    * **Company-Level:** The team package is configured to enherit the official Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`), ensuring we stay aligned with broader company standards.

* **Improved Local Experience:**
    * A new `Makefile` and `Makefile.docs` provide simple targets for authors to validate their work locally before pushing.
    * Running `make vale`, `make lychee` or `make docs-check` locally is now **identical** to the checks run in CI, eliminating surprises.

### Interested in adding this workflow to a project?

You can add this entire standardized workflow to your own repository with a single command.

First, ensure you are in the root of your project on a **new branch** (not `main`), then run:

```bash
bash <(curl -sSL "https://raw.githubusercontent.com/srbouffard/vale-workflow-template/main/bootstrap.sh?$(date +%s)")
```

The script is interactive and will guide you through the setup.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Either discourse-gatekeeper will update the documentation, or I will upon approval of this PR.
There are no user-relevant changes beyond minor documentation changes, so I didn't update the changelog.