### PR TITLE
fix: terraform reference to branch

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -17,7 +17,7 @@ module "jenkins_k8s" {
 }
 
 module "jenkins_agent_k8s" {
-  source      = "git::https://github.com/canonical/jenkins-agent-k8s-operator//terraform/charm?ref=feat/terraform-module"
+  source      = "git::https://github.com/canonical/jenkins-agent-k8s-operator//terraform/charm"
   app_name    = var.jenkins_agent_k8s.app_name
   channel     = var.jenkins_agent_k8s.channel
   config      = var.jenkins_agent_k8s.config


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Remove terraform module development branch refrence
<!-- A high level overview of the change -->

### Rationale

- Accidental commit that's been merged by automerge
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

No charm/application changes.
<!-- Explanation for any unchecked items above -->
