### PR TITLE
fix: reconcile agents on upgrade charm

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ Each revision is versioned by the date of the revision.
 
 ### 2025-09-10
 
-- Added terraform module for charm and Jenkins product,
+- Added terraform module for charm and Jenkins product.
 - Fix issue with service check which did not correctly report when service is ready for
     interaction.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,30 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-09-16
+
+- Fix issue where the agents were not reconciled in previous revisions to reconcile on charm 
+    upgrade.
+
 ### 2025-09-10
 
-- Added terraform module for charm and Jenkins product
+- Added terraform module for charm and Jenkins product,
 - Fix issue with service check which did not correctly report when service is ready for
     interaction.
 
 ### 2025-09-09
 
-- Ejected deprecated `agent-deprecated`:`jenkins-slave` relation
+- Ejected deprecated `agent-deprecated`:`jenkins-slave` relation.
 
 ### 2025-09-05
 
-- Fix issue with Jenkins agent node server discovery when ingress is applied to server
-- Fix race condition with agent trying to register before service ready
+- Fix issue with Jenkins agent node server discovery when ingress is applied to server.
+- Fix race condition with agent trying to register before service ready.
 
 ### 2025-09-02
 
-- Upgrade Jenkins version to latest LTS (v2.516.2)
-- Upgrade Ubuntu base to Noble
+- Upgrade Jenkins version to latest LTS (v2.516.2).
+- Upgrade Ubuntu base to Noble.
 
 ### 2025-05-01
 
-- Added how-to landing page 
+- Added how-to landing page.
 
 ### 2025-04-01
 
-- docs: changelog added
+- docs: changelog added.

--- a/src/charm.py
+++ b/src/charm.py
@@ -178,6 +178,7 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         # Update the agent discovery address.
         # Updating the secret is not required since it's calculated using the agent's node name.
         self.agent_observer.reconfigure_agent_discovery(event)
+        self.agent_observer.reconcile_agents(event)
 
     def jenkins_set_storage_config(self, event: ops.framework.EventBase) -> None:
         """Correctly set permissions when storage is attached.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Reconcile agents on charm upgrade
<!-- A high level overview of the change -->

### Rationale

- Previous revisions may not have the agents reconciled - fixes: #268 
<!-- The reason the change is needed -->

### Juju Events Changes

- On refresh charm, the agent is reconciled.
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

No user facing changes.
<!-- Explanation for any unchecked items above -->
