### PR TITLE
feat: terraform product support (ingress, certificates, oauth2-proxy)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-09-29
+
+- Terraform product module supports ingress, certificates, oauth2-proxy.
+
 ### 2025-09-23
 
 - Support updated auth-proxy relation.

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -8,17 +8,17 @@ output "app_name" {
 
 output "requires" {
   value = {
-    agent = "agent"
-    ingress = "ingress"
-    agent_discovery_ingress = "ingress"
-    auth_proxy = "auth_proxy"
-    logging = "loki_push_api"
+    agent                   = "agent"
+    ingress                 = "ingress"
+    agent_discovery_ingress = "agent-discovery-ingress"
+    auth_proxy              = "auth-proxy"
+    logging                 = "loki_push_api"
   }
 }
 
 output "provides" {
   value = {
-    metrics_endpoint = "prometheus_scrape"
+    metrics_endpoint  = "prometheus_scrape"
     grafana_dashboard = "grafana_dashboard"
   }
 }

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -41,3 +41,141 @@ resource "juju_integration" "jenkins_k8s_jenkins_agent_k8s_agent" {
     endpoint = module.jenkins_agent_k8s.provides.agent
   }
 }
+
+resource "juju_application" "public_ingress" {
+  name  = var.public_ingress.app_name
+  model = var.model
+
+  charm {
+    name     = "traefik-k8s"
+    channel  = var.public_ingress.channel
+    revision = var.public_ingress.revision
+    base     = var.public_ingress.base
+  }
+
+  config      = var.public_ingress.config
+  constraints = var.public_ingress.constraints
+  units       = 1
+
+  trust = true
+}
+
+resource "juju_integration" "jenkins_k8s_public_ingress" {
+  model = var.model
+  application {
+    name     = module.jenkins_k8s.app_name
+    endpoint = module.jenkins_k8s.requires.ingress
+  }
+
+  application {
+    name     = juju_application.public_ingress.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_application" "agent_discovery_ingress" {
+  name  = var.agent_discovery_ingress.app_name
+  model = var.model
+
+  charm {
+    name     = "traefik-k8s"
+    channel  = var.agent_discovery_ingress.channel
+    revision = var.agent_discovery_ingress.revision
+    base     = var.agent_discovery_ingress.base
+  }
+
+  config      = var.agent_discovery_ingress.config
+  constraints = var.agent_discovery_ingress.constraints
+  units       = 1
+
+  trust = true
+}
+
+resource "juju_integration" "jenkins_k8s_agent_discovery_ingress" {
+  model = var.model
+  application {
+    name     = module.jenkins_k8s.app_name
+    endpoint = module.jenkins_k8s.requires.agent_discovery_ingress
+  }
+  application {
+    name     = juju_application.agent_discovery_ingress.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_application" "oauth2_proxy_k8s" {
+  name  = var.oauth2_proxy.app_name
+  model = var.model
+
+  charm {
+    name     = "oauth2-proxy-k8s"
+    channel  = var.oauth2_proxy.channel
+    revision = var.oauth2_proxy.revision
+    base     = var.oauth2_proxy.base
+  }
+
+  config      = var.oauth2_proxy.config
+  constraints = var.oauth2_proxy.constraints
+  units       = 1
+}
+
+resource "juju_integration" "jenkins_k8s_oauth2_proxy_k8s" {
+  model = var.model
+  application {
+    name     = module.jenkins_k8s.app_name
+    endpoint = module.jenkins_k8s.requires.auth_proxy
+  }
+  application {
+    name     = juju_application.oauth2_proxy_k8s.name
+    endpoint = "auth-proxy"
+  }
+}
+
+resource "juju_integration" "public_ingress_oauth2_proxy_k8s" {
+  model = var.model
+  application {
+    name     = juju_application.public_ingress.name
+    endpoint = "ingress"
+  }
+  application {
+    name     = juju_application.oauth2_proxy_k8s.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_application" "certificate_provider" {
+  name  = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.app_name : var.self_signed_ceritificates.app_name
+  model = var.model
+
+  charm {
+    name     = var.use_httprequest_lego_k8s_certificates ? "httprequest-lego-k8s" : "self-signed-certificates"
+    channel  = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.channel : var.self_signed_ceritificates.channel
+    revision = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.revision : var.self_signed_ceritificates.revision
+    base     = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.base : var.self_signed_ceritificates.base
+  }
+
+  config      = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.config : var.self_signed_ceritificates.config
+  constraints = var.use_httprequest_lego_k8s_certificates ? var.httprequest_lego_k8s.constraints : var.self_signed_ceritificates.constraints
+  units       = 1
+}
+
+resource "juju_integration" "public_ingress_certificates" {
+  model = var.model
+  application {
+    name     = juju_application.certificate_provider.name
+    endpoint = "certificates"
+  }
+  application {
+    name     = juju_application.public_ingress.name
+    endpoint = "certificates"
+  }
+}
+
+# # If auth-proxy SaaS given
+# resource "juju_integration" "auth_proxy_receive_certs" {
+
+# }
+
+# resource "juju_integration" "auth_proxy_receive_certs" {
+
+# }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -13,7 +13,7 @@ variable "jenkins_agent_k8s" {
     config      = optional(map(string), {})
     constraints = optional(string, "")
     revision    = optional(number)
-    base        = optional(string, "ubuntu@24.04")
+    base        = optional(string, "ubuntu@22.04")
     units       = optional(number, 3)
   })
 }
@@ -25,6 +25,80 @@ variable "jenkins_k8s" {
     config      = optional(map(string), {})
     constraints = optional(string, "")
     revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+  })
+}
+
+variable "public_ingress" {
+  type = object({
+    app_name = optional(string, "public-traefik-k8s")
+    channel  = optional(string, "latest/edge")
+    config = optional(map(string), {
+      "enable_experimental_forward_auth" : "true",
+      "external_hostname" : ""
+    })
+    constraints = optional(string, "")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@20.04")
+  })
+}
+
+variable "agent_discovery_ingress" {
+  type = object({
+    app_name    = optional(string, "agent-discovery-traefik-k8s")
+    channel     = optional(string, "latest/edge")
+    config      = optional(map(string), {})
+    constraints = optional(string, "")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@20.04")
+  })
+}
+
+variable "oauth2_proxy" {
+  type = object({
+    app_name    = optional(string, "oauth2-proxy-k8s")
+    channel     = optional(string, "latest/edge")
+    config      = optional(map(string), {})
+    constraints = optional(string, "")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+  })
+}
+
+variable "httprequest_lego_k8s" {
+  type = object({
+    app_name = optional(string, "httprequest-lego-k8s")
+    channel  = optional(string, "latest/edge")
+    config = optional(map(string), {
+      "email" : "",
+      "httpreq_endpoint" : "",
+      "httpreq_http_timeout" : "180",
+      "httpreq_password" : "",
+      "httpreq_propagation_timeout" : "600"
+      "httpreq_username" : ""
+    })
+    constraints = optional(string, "")
+    revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")
   })
+}
+
+variable "self_signed_ceritificates" {
+  type = object({
+    app_name    = optional(string, "self-signed-certificates")
+    channel     = optional(string, "1/stable")
+    config      = optional(map(string), {})
+    constraints = optional(string, "")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@24.04")
+  })
+}
+
+variable "use_httprequest_lego_k8s_certificates" {
+  type        = bool
+  default     = false
+  description = <<EOT
+  Whether to use httprequest lego k8s to receive ceritificates.
+  Uses self-signed-certificates by default otherwise.
+  EOT
 }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Add suport to ingress, certificate, oauth2-proxy
<!-- A high level overview of the change -->

### Rationale

- To support a more complete product terraform deployment.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

Terraform changes only, no charm changes applied.
<!-- Explanation for any unchecked items above -->
