### PR TITLE
fix(terraform): remove reference to undeclared null_resource.wait_for_certs_settle

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -145,7 +145,7 @@ resource "juju_integration" "public_ingress_oauth2_proxy_k8s" {
 resource "juju_integration" "jenkins_k8s_jenkins_agent_k8s_agent" {
   model = var.model
 
-  depends_on = [null_resource.wait_for_jenkins_up, null_resource.wait_for_certs_settle]
+  depends_on = [null_resource.wait_for_jenkins_up]
 
   application {
     name     = module.jenkins_k8s.app_name


### PR DESCRIPTION
## Problem

The product module's `jenkins_k8s_jenkins_agent_k8s_agent` integration references `null_resource.wait_for_certs_settle` in `depends_on`, but this resource was removed when certificate management was extracted from the module. This causes `terraform init`/`plan` to fail:

```
Error: Reference to undeclared resource

  on .terraform/modules/jenkins/terraform/product/main.tf line 148:
 148:   depends_on = [null_resource.wait_for_jenkins_up, null_resource.wait_for_certs_settle]

A managed resource "null_resource" "wait_for_certs_settle" has not been declared in module.jenkins.
```

## Fix

Remove the stale reference, keeping only the valid `null_resource.wait_for_jenkins_up` dependency.