### PR TITLE
fix: add retry and API readiness check to bootstrap token generation

### DIFF
--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -23,6 +23,7 @@ import jenkinsapi.jenkins
 import jenkinsapi.utils.requester
 import ops
 import requests
+import tenacity
 from jenkinsapi.node import Node
 from pydantic import HttpUrl
 
@@ -223,6 +224,37 @@ class Jenkins:
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             return False
 
+    def _is_api_ready(self, container: ops.Container) -> bool:
+        """Check if Jenkins API is fully functional (crumb issuance works).
+
+        This is a stronger readiness check than _is_ready. Jenkins may serve pages
+        (login_url returns 200) before its security subsystem is fully initialized.
+        This method verifies that the crumb issuer endpoint is functional, which is
+        required for API token generation during bootstrap.
+
+        Args:
+            container: The Jenkins workload container (for reading admin credentials).
+
+        Returns:
+            True if Jenkins API is fully functional. False otherwise.
+        """
+        try:
+            creds = get_admin_credentials(container)
+            resp = requests.get(
+                f"{self.web_url}/crumbIssuer/api/json",
+                auth=(creds.username, creds.password_or_token),
+                timeout=10,
+            )
+            return resp.ok and "crumb" in resp.json()
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.JSONDecodeError,
+            KeyError,
+            ops.pebble.PathError,
+        ):
+            return False
+
     def wait_ready(self, timeout: int = 300, check_interval: int = 10) -> None:
         """Wait until Jenkins service is up.
 
@@ -293,24 +325,60 @@ class Jenkins:
         Raises:
             JenkinsBootstrapError: if the token can not be setup.
         """
+        # Wait for Jenkins API to be fully ready (crumb issuer functional)
+        # before attempting token generation. Jenkins may serve pages before
+        # its security subsystem is initialized, causing crumb/session races.
+        try:
+            _wait_for(lambda: self._is_api_ready(container), timeout=120, check_interval=5)
+        except TimeoutError as exc:
+            raise JenkinsBootstrapError(
+                "Timed out waiting for Jenkins API to become ready."
+            ) from exc
+
+        try:
+            self._generate_user_token(container)
+        except jenkinsapi.custom_exceptions.JenkinsAPIException as exc:
+            raise JenkinsBootstrapError("Failed to setup user token") from exc
+        except JenkinsBootstrapError:
+            raise
+        except ops.pebble.PathError as exc:
+            raise JenkinsBootstrapError("Failed to setup user token.") from exc
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(5),
+        wait=tenacity.wait_exponential(multiplier=2, min=2, max=30),
+        retry=tenacity.retry_if_exception_type(
+            jenkinsapi.custom_exceptions.JenkinsAPIException
+        ),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def _generate_user_token(self, container: ops.Container) -> None:
+        """Generate and store the admin user API token with retry.
+
+        Creates a fresh client on each attempt to ensure a new session/crumb pair.
+
+        Args:
+            container: The Jenkins workload container.
+
+        Raises:
+            JenkinsBootstrapError: if the token can not be generated after retries.
+        """
         try:
             client = self._get_client(get_admin_credentials(container))
             token: str = client.generate_new_api_token(JUJU_API_TOKEN)
             container.push(API_TOKEN_PATH, token, user=USER, group=GROUP)
-        except ops.pebble.PathError as exc:
-            raise JenkinsBootstrapError("Failed to setup user token.") from exc
-        except jenkinsapi.utils.requester.JenkinsAPIException as e:
-            # Jenkins api exception when generating user token
-            # We check if security is disabled
-            logger.info("Generate token failed, checking if security is disabled")
-            response = client.requester.get_url(
-                f"{client.base_server_url()}/manage/api/json?tree=useSecurity"
-            )
+        except jenkinsapi.custom_exceptions.JenkinsAPIException as e:
+            # Check if security is disabled before retrying
             try:
-                if response.status_code == 200 and not response.json()["useSecurity"]:
-                    # !! Write a random string to the api token as a temporary workaround,
-                    # Prefix it to signify that it's a placeholder token
-                    # Follow-up changes will be needed to rework this.
+                check_response = requests.get(
+                    f"{self.web_url}/manage/api/json?tree=useSecurity",
+                    timeout=10,
+                )
+                if check_response.status_code == 200 and not check_response.json()[
+                    "useSecurity"
+                ]:
+                    # Security disabled — write placeholder token
                     container.push(
                         API_TOKEN_PATH,
                         f"placeholder-{secrets.token_hex(16)}",
@@ -318,16 +386,15 @@ class Jenkins:
                         group=GROUP,
                     )
                     return
-            # Not in the case where security is disabled, reraise the exception
             except (requests.exceptions.JSONDecodeError, KeyError):
                 logger.error(
-                    "Failed parsing jenkins's security config in response, will raise initial error"
+                    "Failed parsing jenkins's security config, will retry"
                 )
-            logger.error(
-                "Generate token failed but security is not disabled, API response: HTTP %s",
-                response.status_code,
+            logger.warning(
+                "Token generation failed (API response may indicate crumb/session race): %s",
+                e,
             )
-            raise JenkinsBootstrapError("Failed to setup user token") from e
+            raise
 
     def _configure_proxy(
         self, container: ops.Container, proxy_config: state.ProxyConfig | None = None

--- a/tests/integration/test_bootstrap_race.py
+++ b/tests/integration/test_bootstrap_race.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for Jenkins bootstrap race conditions."""
+
+import logging
+
+import pytest
+from juju.application import Application
+from juju.model import Model
+from juju.unit import Unit
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_bootstrap_with_ingress_prefix(
+    model: Model, charm: str, jenkins_image: str, ops_test: OpsTest
+):
+    """
+    arrange: deploy Jenkins with traefik ingress to set a non-trivial prefix.
+    act: wait for the charm to bootstrap.
+    assert: the charm reaches active status (bootstrap succeeded despite prefix).
+
+    This catches crumb/session race conditions where the JENKINS_PREFIX causes
+    crumb URLs and token generation URLs to diverge, invalidating session-bound crumbs.
+    """
+    resources = {"jenkins-image": jenkins_image}
+    app_name = "jenkins-prefix-test"
+
+    # Deploy traefik for ingress (sets prefix on the jenkins app)
+    traefik_app = await model.deploy(
+        "traefik-k8s",
+        application_name="traefik-prefix",
+        channel="latest/stable",
+        trust=True,
+    )
+
+    application = await model.deploy(
+        charm,
+        resources=resources,
+        application_name=app_name,
+    )
+
+    # Relate to traefik — this sets JENKINS_PREFIX to /<model>-<app>-<unit>
+    await model.integrate(f"{app_name}:ingress", "traefik-prefix:ingress")
+
+    await model.wait_for_idle(
+        apps=[application.name],
+        raise_on_error=False,
+        wait_for_active=True,
+        raise_on_blocked=True,
+        timeout=30 * 60,
+        idle_period=30,
+    )
+    assert application.status == "active", (
+        f"Jenkins with ingress prefix failed to bootstrap: {application.status}"
+    )
+    # Cleanup
+    await application.remove()
+    await traefik_app.remove()
+    await model.block_until(lambda: app_name not in model.applications, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+async def test_bootstrap_after_restart(application: Application, unit: Unit):
+    """
+    arrange: a running Jenkins deployment.
+    act: delete the API token file and restart the workload to re-trigger bootstrap.
+    assert: the charm re-bootstraps successfully and returns to active status.
+
+    This exercises the bootstrap code path (crumb fetch + token generation) on an
+    already-initialized Jenkins instance, which is more likely to hit the crumb/session
+    race because Jenkins's security subsystem restarts with existing state.
+    """
+    # Delete the API token to force re-bootstrap on next pebble-ready
+    action = await unit.run(
+        "PEBBLE_SOCKET=/charm/containers/jenkins/pebble.socket "
+        "/charm/bin/pebble exec -- rm -f /var/lib/jenkins/juju_api_token"
+    )
+    await action.wait()
+
+    # Restart the jenkins service — triggers pebble-ready → bootstrap
+    action = await unit.run(
+        "PEBBLE_SOCKET=/charm/containers/jenkins/pebble.socket "
+        "/charm/bin/pebble restart jenkins"
+    )
+    await action.wait()
+    assert action.status == "completed", f"Failed to restart jenkins: {action.data}"
+
+    # Wait for the charm to re-settle — if crumb race hits, this will error/block
+    model = unit.model
+    await model.wait_for_idle(
+        apps=[application.name],
+        raise_on_error=False,
+        wait_for_active=True,
+        raise_on_blocked=True,
+        timeout=10 * 60,
+        idle_period=30,
+    )
+    assert application.status == "active", (
+        f"Jenkins failed to re-bootstrap after restart: {application.status}"
+    )

--- a/tests/unit/test_jenkins.py
+++ b/tests/unit/test_jenkins.py
@@ -260,7 +260,10 @@ def test__setup_user_token(harness_container: HarnessWithContainer, mock_env: je
     mock_client = MagicMock(spec=jenkinsapi.jenkins.Jenkins)
     mock_client.generate_new_api_token.return_value = test_api_token
 
-    with patch.object(jenkins.Jenkins, "_get_client") as get_client_mock:
+    with (
+        patch.object(jenkins.Jenkins, "_get_client") as get_client_mock,
+        patch.object(jenkins.Jenkins, "_is_api_ready", return_value=True),
+    ):
         get_client_mock.return_value = mock_client
         jenkins.Jenkins(mock_env)._setup_user_token(harness_container.container)
 
@@ -283,7 +286,10 @@ def test__setup_user_token_raises_exception(mock_env: jenkins.Environment):
     mock_container.pull = MagicMock(
         side_effect=ops.pebble.PathError(kind="not-found", message="Path not found.")
     )
-    with patch.object(jenkins.Jenkins, "_get_client") as get_client_mock:
+    with (
+        patch.object(jenkins.Jenkins, "_get_client") as get_client_mock,
+        patch.object(jenkins.Jenkins, "_is_api_ready", return_value=True),
+    ):
         get_client_mock.return_value = mock_client
 
         with pytest.raises(jenkins.JenkinsBootstrapError):
@@ -317,7 +323,11 @@ def test__setup_user_token_security_disabled_response_parse_error(
     requester_mock.get_url = MagicMock(return_value=jenkins_security_response_mock)
     mock_client.requester = requester_mock
     mock_container = MagicMock(ops.Container)
-    with patch.object(jenkins.Jenkins, "_get_client") as get_client_mock:
+    with (
+        patch.object(jenkins.Jenkins, "_get_client") as get_client_mock,
+        patch.object(jenkins.Jenkins, "_is_api_ready", return_value=True),
+        patch("jenkins.requests.get", return_value=jenkins_security_response_mock),
+    ):
         get_client_mock.return_value = mock_client
 
         with pytest.raises(jenkins.JenkinsBootstrapError):
@@ -341,7 +351,11 @@ def test__setup_user_token_security_disabled_push_placeholder_token(mock_env: je
     mock_container = MagicMock(ops.Container)
     push_mock = MagicMock()
     mock_container.push = push_mock
-    with patch.object(jenkins.Jenkins, "_get_client") as get_client_mock:
+    with (
+        patch.object(jenkins.Jenkins, "_get_client") as get_client_mock,
+        patch.object(jenkins.Jenkins, "_is_api_ready", return_value=True),
+        patch("jenkins.requests.get", return_value=jenkins_security_response_mock),
+    ):
         get_client_mock.return_value = mock_client
         jenkins.Jenkins(mock_env)._setup_user_token(mock_container)
         push_mock.assert_called_once()
@@ -364,7 +378,11 @@ def test__setup_user_token_security_disabled_raise_original_error(mock_env: jenk
     mock_container = MagicMock(ops.Container)
     pull_mock = MagicMock()
     mock_container.pull = pull_mock
-    with patch.object(jenkins.Jenkins, "_get_client") as get_client_mock:
+    with (
+        patch.object(jenkins.Jenkins, "_get_client") as get_client_mock,
+        patch.object(jenkins.Jenkins, "_is_api_ready", return_value=True),
+        patch("jenkins.requests.get", return_value=jenkins_security_response_mock),
+    ):
         get_client_mock.return_value = mock_client
 
         with pytest.raises(jenkins.JenkinsBootstrapError):


### PR DESCRIPTION
## Problem

The Jenkins bootstrap process fails with a crumb/session race condition on Jenkins 2.516.3. When Jenkins starts, it may serve pages (login URL returns HTTP 200) before its security subsystem (crumb issuance, session management) is fully initialized. This causes `generate_new_api_token` to fail with HTTP 500 because:

1. The crumb fetched during client creation is tied to a session cookie
2. By the time the POST fires, Jenkins either hasn't fully initialized or the session isn't preserved
3. Jenkins rejects the request as unauthenticated (returns 'Sign in' page)

This is particularly likely when `JENKINS_PREFIX` is set (as in production deployments).

## Fix

**Option A - Retry with backoff:** Added `tenacity` retry (5 attempts, exponential backoff 2-30s) on the new `_generate_user_token()` method. Each retry creates a fresh client with a new session/crumb pair.

**Option B - API readiness gate:** Added `_is_api_ready()` that verifies the crumb issuer endpoint is functional before attempting token generation. This is a stronger check than the existing `_is_ready()` which only checks the login page.

## Integration Tests

- `test_bootstrap_with_prefix`: Deploys Jenkins with a non-trivial prefix (like production) to catch crumb URL mismatches
- `test_bootstrap_after_restart`: Deletes the API token and restarts the workload to re-trigger the bootstrap code path

## Testing

Unit tests: all 222 pass