### PR TITLE
feat(jcasc): add jcasc-config charm config option and state property

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -118,6 +118,32 @@ config:
         Comma-separated JVM system properties to pass to the Jenkins process at startup.
         Specify entries as key=value without the -D prefix. These are appended as -Dkey=value.
         Example: jenkins.model.Jenkins.crumbIssuerProxyCompatibility=true
+    jcasc-config:
+      type: string
+      description: |
+        Jenkins Configuration as Code (JCasC) YAML content. This is the declarative
+        way to manage Jenkins configuration (security, clouds, credentials, views, etc.).
+        The charm auto-injects admin credentials if the user config omits securityRealm,
+        and injects auth proxy config when the relation is active.
+        See https://www.jenkins.io/projects/jcasc/ for schema reference.
+      default: |
+        jenkins:
+          systemMessage: "Managed by jenkins-k8s charm via JCasC\n"
+          numExecutors: 0
+          securityRealm:
+            local:
+              allowsSignup: false
+              users:
+                - id: "admin"
+                  password: "${JENKINS_ADMIN_PASSWORD}"
+          authorizationStrategy:
+            loggedInUsersCanDoAnything:
+              allowAnonymousRead: false
+          crumbIssuer:
+            standard:
+              excludeClientIPFromCrumb: true
+          remotingSecurity:
+            enabled: true
 
 actions:
   get-admin-password:

--- a/src/state.py
+++ b/src/state.py
@@ -197,6 +197,7 @@ class State:
         proxy_config: Proxy configuration to access Jenkins upstream through.
         plugins: The list of allowed plugins to install.
         auth_proxy_integrated: if an auth proxy integrated has been set.
+        jcasc_config: Raw JCasC YAML content from charm config.
         system_properties: Additional JVM system properties as -D flags.
 
     """
@@ -206,6 +207,7 @@ class State:
     proxy_config: typing.Optional[ProxyConfig]
     plugins: typing.Optional[typing.Iterable[str]]
     auth_proxy_integrated: bool
+    jcasc_config: str
     system_properties: typing.List[str] = dataclasses.field(default_factory=list)
 
     @classmethod
@@ -284,5 +286,6 @@ class State:
             plugins=plugins,
             proxy_config=proxy_config,
             auth_proxy_integrated=is_auth_proxy_integrated,
+            jcasc_config=typing.cast(str, charm.config.get("jcasc-config") or ""),
             system_properties=system_properties,
         )

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -322,3 +322,28 @@ def test_agent_meta_from_relation_data_complete():
     )
     assert result is not None
     assert result.name == "agent-0"
+
+
+def test_jcasc_config_from_charm(mock_charm: MagicMock):
+    """
+    arrange: given a charm with jcasc-config set.
+    act: when state is initialized from charm.
+    assert: jcasc_config contains the config value.
+    """
+    test_config = "jenkins:\n  systemMessage: test\n"
+    mock_charm.config = {"jcasc-config": test_config}
+
+    config = state.State.from_charm(mock_charm)
+    assert config.jcasc_config == test_config
+
+
+def test_jcasc_config_default(mock_charm: MagicMock):
+    """
+    arrange: given a charm with no explicit jcasc-config.
+    act: when state is initialized from charm.
+    assert: jcasc_config returns empty string (default from get).
+    """
+    mock_charm.config = {}
+
+    config = state.State.from_charm(mock_charm)
+    assert config.jcasc_config == ""


### PR DESCRIPTION
## Summary
Add `jcasc-config` string option to `charmcraft.yaml` with a sensible default YAML that configures:
- Admin credentials via \${JENKINS_ADMIN_PASSWORD} env var
- Crumb issuer (CSRF protection)
- Standard security realm

Add `jcasc_config: str` field to the `State` dataclass, populated from `charm.config['jcasc-config']`.

## Testing
- `test_jcasc_config_from_charm`: verifies config value is populated into state
- `test_jcasc_config_default`: verifies empty string default when unset

## Stack
- PR1 #379: Plugin + constant ← main
- **PR2 (this) #380**: Charm config option + state property + tests ← PR1
- PR3 #381: Pebble environment variables + test update ← PR2
- PR4 #382: Reconciliation logic + unit/integration tests ← PR3

## Ref
ISD-5501