### PR TITLE
feat(jcasc): add CASC_JENKINS_CONFIG and JENKINS_ADMIN_PASSWORD to Pebble env

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -160,8 +160,14 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             return ""
         return path
 
-    def calculate_env(self) -> jenkins.Environment:
+    def calculate_env(
+        self, admin_password: str = ""
+    ) -> jenkins.Environment:
         """Return a dictionary for Jenkins Pebble layer.
+
+        Args:
+            admin_password: The admin password for JCasC secret interpolation.
+                Empty string if not yet available (e.g. during __init__).
 
         Returns:
             The dictionary mapping of environment variables for the Jenkins service.
@@ -169,6 +175,8 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         return jenkins.Environment(
             JENKINS_HOME=str(jenkins.JENKINS_HOME_PATH),
             JENKINS_PREFIX=self._get_ingress_path(),
+            CASC_JENKINS_CONFIG=str(jenkins.JCASC_CONFIG_PATH),
+            JENKINS_ADMIN_PASSWORD=admin_password,
         )
 
     def _reconcile(self, event: ops.EventBase) -> None:
@@ -220,8 +228,14 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             container: The Jenkins workload container.
             charm_state: The current charm state.
         """
-        # Recalculate environment to pick up changes (e.g. ingress prefix)
-        self.jenkins.environment = self.calculate_env()
+        # Recalculate environment to pick up changes (e.g. ingress prefix, admin password)
+        admin_password = ""
+        try:
+            credentials = jenkins.get_admin_credentials(container)
+            admin_password = credentials.password_or_token
+        except (ops.pebble.PathError, FileNotFoundError):
+            pass  # Password not yet available (first boot)
+        self.jenkins.environment = self.calculate_env(admin_password=admin_password)
         desired_layer = pebble.get_pebble_layer(self.jenkins, charm_state)
         try:
             current_services = container.get_plan().services

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -102,10 +102,14 @@ class Environment(typing.TypedDict):
     Attributes:
         JENKINS_HOME: The Jenkins home directory.
         JENKINS_PREFIX: The prefix in which Jenkins will be accessible.
+        CASC_JENKINS_CONFIG: Path to the JCasC configuration file.
+        JENKINS_ADMIN_PASSWORD: The admin password for JCasC secret interpolation.
     """
 
     JENKINS_HOME: str
     JENKINS_PREFIX: str
+    CASC_JENKINS_CONFIG: str
+    JENKINS_ADMIN_PASSWORD: str
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -304,7 +304,12 @@ def test_calculate_env(harness: Harness):
     with patch.object(jenkins_charm, "_get_ingress_path", return_value=""):
         env = jenkins_charm.calculate_env()
 
-    assert env == {"JENKINS_HOME": str(jenkins.JENKINS_HOME_PATH), "JENKINS_PREFIX": ""}
+    assert env == {
+        "JENKINS_HOME": str(jenkins.JENKINS_HOME_PATH),
+        "JENKINS_PREFIX": "",
+        "CASC_JENKINS_CONFIG": str(jenkins.JCASC_CONFIG_PATH),
+        "JENKINS_ADMIN_PASSWORD": "",
+    }
 
 
 def test__on_config_changed_invalid_config_blocked(


### PR DESCRIPTION
## Summary
Add two new environment variables to the Pebble layer:
- `CASC_JENKINS_CONFIG`: points to `JENKINS_HOME/jenkins.yaml` so the JCasC plugin auto-loads it
- `JENKINS_ADMIN_PASSWORD`: injects the admin password for JCasC \${} variable substitution

Update `calculate_env()` to accept an optional `admin_password` parameter.
`_reconcile_pebble` now reads the admin password from the container and passes it to the environment.

## Testing
- Updated `test_calculate_env` to assert on the new env vars

## Stack
- PR1 #379: Plugin + constant ← main
- PR2 #380: Charm config option + state property + tests ← PR1
- **PR3 (this) #381**: Pebble environment variables + test update ← PR2
- PR4 #382: Reconciliation logic + unit/integration tests ← PR3

## Ref
ISD-5501