### PR TITLE
chore: merge reconcile hooks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -87,46 +87,23 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         self._auth_proxy = AuthProxyRequirer(self)
 
         # Register all events to funnel through reconcile
-        self.framework.observe(
+        for event in [
             self.on.jenkins_home_storage_attached,
-            self._on_jenkins_home_storage_attached,
-        )
-        self.framework.observe(self.on.jenkins_pebble_ready, self._on_jenkins_pebble_ready)
-        self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(
-            self.on[AGENT_RELATION].relation_joined, self._on_agent_relation_joined
-        )
-        self.framework.observe(
-            self.on[AGENT_RELATION].relation_departed, self._on_agent_relation_departed
-        )
-        self.framework.observe(
-            self.on[AGENT_RELATION].relation_changed, self._on_agent_relation_changed
-        )
-        self.framework.observe(
+            self.on.upgrade_charm,
+            self.on.config_changed,
+            self.on[AGENT_RELATION].relation_joined,
+            self.on[AGENT_RELATION].relation_departed,
+            self.on[AGENT_RELATION].relation_changed,
             self.agent_discovery_ingress.on.ready,
-            self._on_agent_discovery_ingress_ready,
-        )
-        self.framework.observe(
             self.agent_discovery_ingress.on.revoked,
-            self._on_agent_discovery_ingress_revoked,
-        )
-        self.framework.observe(
             self.server_ingress.on.ready,
-            self._on_server_ingress_ready,
-        )
-        self.framework.observe(
             self.server_ingress.on.revoked,
-            self._on_server_ingress_revoked,
-        )
-        self.framework.observe(
-            self.on[AUTH_PROXY_RELATION].relation_joined, self._on_auth_proxy_relation_joined
-        )
-        self.framework.observe(
+            self.on[AUTH_PROXY_RELATION].relation_joined,
             self.on[AUTH_PROXY_RELATION].relation_departed,
-            self._on_auth_proxy_relation_departed,
-        )
+            self.on.update_status,
+        ]:
+            self.framework.observe(event, self._reconcile)
+        self.framework.observe(self.on.jenkins_pebble_ready, self._on_jenkins_pebble_ready)
         self.framework.observe(self.on.get_admin_password_action, self._on_get_admin_password)
         self.framework.observe(self.on.rotate_credentials_action, self._on_rotate_credentials)
 
@@ -134,7 +111,8 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         """Derive the charm state fresh from current config and relation data.
 
         Returns:
-            The current charm state, or None if config/units are invalid (unit set to BlockedStatus).
+            The current charm state, or None if config/units are invalid (unit set to
+            BlockedStatus).
 
         Raises:
             RuntimeError: if invalid relation data was received.
@@ -469,110 +447,6 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             event: The event fired when pebble is ready.
         """
         self._bootstrap_jenkins(event)
-
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        """Handle configuration changes.
-
-        Args:
-            event: The config-changed event.
-        """
-        self._reconcile(event)
-
-    def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
-        """Handle update status event.
-
-        Args:
-            event: The update status hook event.
-        """
-        self._reconcile(event)
-
-    def _on_jenkins_home_storage_attached(self, event: ops.StorageAttachedEvent) -> None:
-        """Handle storage attached.
-
-        Args:
-            event: The event fired when the storage is attached.
-        """
-        self._reconcile(event)
-
-    def _on_upgrade_charm(self, event: ops.UpgradeCharmEvent) -> None:
-        """Handle charm upgrade.
-
-        Args:
-            event: The event fired when the charm is upgraded.
-        """
-        self._reconcile(event)
-
-    def _on_agent_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
-        """Handle agent relation joined.
-
-        Args:
-            event: the event fired when an agent joins the relation.
-        """
-        self._reconcile(event)
-
-    def _on_agent_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
-        """Handle agent relation departed.
-
-        Args:
-            event: the event fired when an agent departs the relation.
-        """
-        self._reconcile(event)
-
-    def _on_agent_relation_changed(self, event: ops.RelationChangedEvent) -> None:
-        """Handle agent relation changed.
-
-        Args:
-            event: the event fired when agent relation data changes.
-        """
-        self._reconcile(event)
-
-    def _on_agent_discovery_ingress_ready(self, event: ops.EventBase) -> None:
-        """Handle agent discovery ingress ready event.
-
-        Args:
-            event: the event fired when agent discovery ingress becomes ready.
-        """
-        self._reconcile(event)
-
-    def _on_agent_discovery_ingress_revoked(self, event: ops.EventBase) -> None:
-        """Handle agent discovery ingress revoked event.
-
-        Args:
-            event: the event fired when agent discovery ingress is revoked.
-        """
-        self._reconcile(event)
-
-    def _on_server_ingress_ready(self, event: ops.EventBase) -> None:
-        """Handle server ingress ready event.
-
-        Args:
-            event: the event fired when server ingress becomes ready.
-        """
-        self._reconcile(event)
-
-    def _on_server_ingress_revoked(self, event: ops.EventBase) -> None:
-        """Handle server ingress revoked event.
-
-        Args:
-            event: the event fired when server ingress is revoked.
-        """
-        self._reconcile(event)
-
-    def _on_auth_proxy_relation_joined(self, event: ops.RelationCreatedEvent) -> None:
-        """Handle auth proxy relation joined.
-
-        Args:
-            event: the event fired when the auth proxy relation is joined.
-        """
-        self._reconcile(event)
-
-    def _on_auth_proxy_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
-        """Handle auth proxy relation departed.
-
-        Args:
-            event: the event fired when the auth proxy relation departs.
-        """
-        self._reconcile(event)
 
     def _on_get_admin_password(self, event: ops.ActionEvent) -> None:
         """Handle get-admin-password event.

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -214,7 +214,7 @@ def test_reconcile_agents(
     """
     ctx = testing.Context(JenkinsK8sOperatorCharm)
     with (
-        patch.object(JenkinsK8sOperatorCharm, "_reconcile"),
+        patch.object(JenkinsK8sOperatorCharm, "_reconcile", new=lambda self, event: None),
         ctx(ctx.on.config_changed(), state) as mgr,
     ):
         fake_jenkins_service = FakeJenkinsService(initial_agents=initial_agents)
@@ -530,7 +530,7 @@ def test_reconcile_agents_jenkins_not_ready(_mock_ready):
     )
     ctx = testing.Context(JenkinsK8sOperatorCharm)
     with (
-        patch.object(JenkinsK8sOperatorCharm, "_reconcile"),
+        patch.object(JenkinsK8sOperatorCharm, "_reconcile", new=lambda self, event: None),
         ctx(ctx.on.config_changed(), state) as mgr,
     ):
         mock_event = MagicMock()
@@ -559,7 +559,7 @@ def test_reconcile_agent_discovery_updates_relation():
     )
     ctx = testing.Context(JenkinsK8sOperatorCharm)
     with (
-        patch.object(JenkinsK8sOperatorCharm, "_reconcile"),
+        patch.object(JenkinsK8sOperatorCharm, "_reconcile", new=lambda self, event: None),
         ctx(ctx.on.config_changed(), state) as mgr,
     ):
         mgr.charm._reconcile_agent_discovery()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,20 +41,20 @@ def test__on_config_changed_invalid_config_sets_blocked(
     harness_container.harness.begin()
 
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
-    jenkins_charm._on_config_changed(MagicMock(spec=ops.ConfigChangedEvent))
+    jenkins_charm._reconcile(MagicMock(spec=ops.ConfigChangedEvent))
 
     assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME, "unit should be in BlockedStatus"
 
 
 @pytest.mark.parametrize(
-    "event_handler",
+    "event_spec",
     [
-        pytest.param("_on_jenkins_home_storage_attached"),
-        pytest.param("_on_jenkins_pebble_ready"),
-        pytest.param("_on_update_status"),
+        pytest.param(ops.StorageAttachedEvent, id="_on_jenkins_home_storage_attached"),
+        pytest.param(ops.PebbleReadyEvent, id="_on_jenkins_pebble_ready"),
+        pytest.param(ops.UpdateStatusEvent, id="_on_update_status"),
     ],
 )
-def test_workload_not_ready(harness: Harness, event_handler: str):
+def test_workload_not_ready(harness: Harness, event_spec: type):
     """
     arrange: given a charm with no container ready.
     act: when an event hook is fired.
@@ -62,25 +62,25 @@ def test_workload_not_ready(harness: Harness, event_handler: str):
     """
     harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-    handler_func = getattr(jenkins_charm, event_handler)
-    mock_event = MagicMock(spec=ops.WorkloadEvent)
-    mock_event.workload = MagicMock(spec=ops.model.Container)
-    mock_event.workload.can_connect.return_value = False
+    mock_event = MagicMock(spec=event_spec)
 
-    handler_func(mock_event)
+    if event_spec == ops.PebbleReadyEvent:
+        jenkins_charm._on_jenkins_pebble_ready(mock_event)
+    else:
+        jenkins_charm._reconcile(mock_event)
 
     assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
 
 
 @pytest.mark.parametrize(
-    "event_handler",
+    "event_spec",
     [
-        pytest.param("_on_jenkins_home_storage_attached"),
-        pytest.param("_on_jenkins_pebble_ready"),
-        pytest.param("_on_update_status"),
+        pytest.param(ops.StorageAttachedEvent, id="_on_jenkins_home_storage_attached"),
+        pytest.param(ops.PebbleReadyEvent, id="_on_jenkins_pebble_ready"),
+        pytest.param(ops.UpdateStatusEvent, id="_on_update_status"),
     ],
 )
-def test_storage_not_ready(harness: Harness, event_handler: str):
+def test_storage_not_ready(harness: Harness, event_spec: type):
     """
     arrange: given a charm with no storage ready.
     act: when an event hook is fired.
@@ -88,12 +88,12 @@ def test_storage_not_ready(harness: Harness, event_handler: str):
     """
     harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-    handler_func = getattr(jenkins_charm, event_handler)
-    mock_event = MagicMock(spec=ops.WorkloadEvent)
-    mock_event.workload = MagicMock(spec=ops.model.Container)
-    mock_event.workload.can_connect.return_value = True
+    mock_event = MagicMock(spec=event_spec)
 
-    handler_func(mock_event)
+    if event_spec == ops.PebbleReadyEvent:
+        jenkins_charm._on_jenkins_pebble_ready(mock_event)
+    else:
+        jenkins_charm._reconcile(mock_event)
 
     assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
 
@@ -329,7 +329,7 @@ def test__on_config_changed_invalid_config_blocked(
     ):
         from_charm_mock.side_effect = state.CharmConfigInvalidError("bad sysprops")
 
-        jenkins_charm._on_config_changed(MagicMock(spec=ops.ConfigChangedEvent))
+        jenkins_charm._reconcile(MagicMock(spec=ops.ConfigChangedEvent))
 
         assert jenkins_charm.unit.status.name == BLOCKED_STATUS_NAME
         assert jenkins_charm.unit.status.message == "bad sysprops"
@@ -355,7 +355,7 @@ def test__on_config_changed_relation_data_invalid_raises(
         from_charm_mock.side_effect = state.CharmRelationDataInvalidError("bad relation")
 
         with pytest.raises(RuntimeError):
-            jenkins_charm._on_config_changed(MagicMock(spec=ops.ConfigChangedEvent))
+            jenkins_charm._reconcile(MagicMock(spec=ops.ConfigChangedEvent))
 
 
 def test__on_config_changed_precondition_waits_and_defers(
@@ -381,7 +381,7 @@ def test__on_config_changed_precondition_waits_and_defers(
     ):
         check_mock.return_value = precondition._CheckResult(success=False, reason="not ready")
 
-        jenkins_charm._on_config_changed(event)
+        jenkins_charm._reconcile(event)
 
         assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
         assert jenkins_charm.unit.status.message == "not ready"
@@ -418,7 +418,7 @@ def test__on_config_changed_success_replans_and_restarts(
         # Return empty plan so services differ and replan is triggered
         get_plan_mock.return_value = ops.pebble.Plan("")
 
-        jenkins_charm._on_config_changed(MagicMock(spec=ops.ConfigChangedEvent))
+        jenkins_charm._reconcile(MagicMock(spec=ops.ConfigChangedEvent))
 
         add_layer_mock.assert_called_once()
         replan_mock.assert_called_once()
@@ -440,84 +440,80 @@ def test__remove_unlisted_plugins_requires_state(harness_container: HarnessWithC
 
 
 @pytest.mark.parametrize(
-    "handler_name, event_type",
+    "event_type",
     [
-        pytest.param("_on_agent_relation_joined", ops.RelationJoinedEvent, id="joined"),
-        pytest.param("_on_agent_relation_departed", ops.RelationDepartedEvent, id="departed"),
-        pytest.param("_on_agent_relation_changed", ops.RelationChangedEvent, id="changed"),
+        pytest.param(ops.RelationJoinedEvent, id="joined"),
+        pytest.param(ops.RelationDepartedEvent, id="departed"),
+        pytest.param(ops.RelationChangedEvent, id="changed"),
     ],
 )
 def test__agent_relation_handlers_reconcile_agents(
-    harness_container: HarnessWithContainer, handler_name: str, event_type: type[ops.EventBase]
+    harness_container: HarnessWithContainer, event_type: type[ops.EventBase]
 ):
     """
     arrange: given a started charm and a valid derived state.
-    act: when an agent relation handler is called.
-    assert: the handler delegates to _reconcile.
+    act: when an agent relation event triggers _reconcile.
+    assert: reconcile executes without error (delegates internally to _reconcile_agents).
     """
     harness_container.harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     event = MagicMock(spec=event_type)
 
-    with patch.object(jenkins_charm, "_reconcile") as reconcile_mock:
-        getattr(jenkins_charm, handler_name)(event)
+    with patch.object(jenkins_charm, "_reconcile_agents") as reconcile_agents_mock:
+        jenkins_charm._reconcile(event)
 
-    reconcile_mock.assert_called_once_with(event)
+    reconcile_agents_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(
-    "handler_name",
+    "event_spec",
     [
-        pytest.param("_on_agent_discovery_ingress_ready", id="ready"),
-        pytest.param("_on_agent_discovery_ingress_revoked", id="revoked"),
+        pytest.param(ops.EventBase, id="ready"),
+        pytest.param(ops.EventBase, id="revoked"),
     ],
 )
 def test__agent_discovery_ingress_handlers_reconfigure_agents(
-    harness_container: HarnessWithContainer, handler_name: str
+    harness_container: HarnessWithContainer, event_spec: type
 ):
     """
     arrange: given a started charm and a valid derived state.
-    act: when an agent discovery ingress handler is called.
-    assert: the handler delegates to _reconcile.
+    act: when an agent discovery ingress event triggers _reconcile.
+    assert: reconcile executes without error (delegates internally to _reconcile_agent_discovery).
     """
     harness_container.harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
-    event = MagicMock(spec=ops.EventBase)
+    event = MagicMock(spec=event_spec)
 
-    with patch.object(jenkins_charm, "_reconcile") as reconcile_mock:
-        getattr(jenkins_charm, handler_name)(event)
+    with patch.object(jenkins_charm, "_reconcile_agent_discovery") as reconcile_discovery_mock:
+        jenkins_charm._reconcile(event)
 
-    reconcile_mock.assert_called_once_with(event)
+    reconcile_discovery_mock.assert_called_once()
 
 
 def test__upgrade_charm_reconciles_storage_and_agents(harness_container: HarnessWithContainer):
     """
     arrange: given a started charm and a valid derived state.
-    act: when the upgrade-charm handler is called.
-    assert: _reconcile is called with the event.
+    act: when the upgrade-charm event triggers _reconcile.
+    assert: _reconcile_storage is called (UpgradeCharmEvent triggers storage reconciliation).
     """
     harness_container.harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     event = MagicMock(spec=ops.UpgradeCharmEvent)
 
-    with patch.object(jenkins_charm, "_reconcile") as reconcile_mock:
-        jenkins_charm._on_upgrade_charm(event)
+    with patch.object(jenkins_charm, "_reconcile_storage") as reconcile_storage_mock:
+        jenkins_charm._reconcile(event)
 
-    reconcile_mock.assert_called_once_with(event)
+    reconcile_storage_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(
-    "handler_name, observer_name, event_type",
+    "event_type",
     [
         pytest.param(
-            "_on_auth_proxy_relation_joined",
-            "on_auth_proxy_relation_joined",
             ops.RelationCreatedEvent,
             id="joined",
         ),
         pytest.param(
-            "_on_auth_proxy_relation_departed",
-            "on_auth_proxy_relation_departed",
             ops.RelationDepartedEvent,
             id="departed",
         ),
@@ -525,20 +521,18 @@ def test__upgrade_charm_reconciles_storage_and_agents(harness_container: Harness
 )
 def test__auth_proxy_relation_handlers_delegate(
     harness_container: HarnessWithContainer,
-    handler_name: str,
-    observer_name: str,
     event_type: type[ops.EventBase],
 ):
     """
     arrange: given a started charm and a valid derived state.
-    act: when an auth-proxy relation handler is called.
-    assert: the handler delegates to _reconcile.
+    act: when an auth-proxy relation event triggers _reconcile.
+    assert: reconcile executes without error (delegates internally to _reconcile_auth_proxy).
     """
     harness_container.harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
     event = MagicMock(spec=event_type)
 
-    with patch.object(jenkins_charm, "_reconcile") as reconcile_mock:
-        getattr(jenkins_charm, handler_name)(event)
+    with patch.object(jenkins_charm, "_reconcile_auth_proxy") as reconcile_auth_mock:
+        jenkins_charm._reconcile(event)
 
-    reconcile_mock.assert_called_once_with(event)
+    reconcile_auth_mock.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -60,6 +60,7 @@ def test_workload_not_ready(harness: Harness, event_spec: type):
     act: when an event hook is fired.
     assert: the charm falls into waiting status.
     """
+    harness.add_storage(state.JENKINS_HOME_STORAGE_NAME, count=1, attach=True)
     harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
     mock_event = MagicMock(spec=event_spec)
@@ -88,6 +89,8 @@ def test_storage_not_ready(harness: Harness, event_spec: type):
     """
     harness.begin()
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    container = harness.model.unit.get_container("jenkins")
+    harness.set_can_connect(container, True)
     mock_event = MagicMock(spec=event_spec)
 
     if event_spec == ops.PebbleReadyEvent:
@@ -510,7 +513,7 @@ def test__upgrade_charm_reconciles_storage_and_agents(harness_container: Harness
     "event_type",
     [
         pytest.param(
-            ops.RelationCreatedEvent,
+            ops.RelationJoinedEvent,
             id="joined",
         ),
         pytest.param(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Merge all hooks that reconcile & remove individual handler routing hooks.
<!-- A high level overview of the change -->

### Rationale

The charm is going holistic, we no longer need to wrap reconcile to individual hooks.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
All hooks apart from actions & pebble ready hook mapped to reconcile

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

No user facing changes
<!-- Explanation for any unchecked items above -->
