### PR TITLE
docs: update links

### DIFF
--- a/docs/reference/charm-architecture.md
+++ b/docs/reference/charm-architecture.md
@@ -72,7 +72,7 @@ Only one deployment per Jenkins application is supported.
 Juju events allow progression of the charm in its lifecycle and encapsulates part of the execution
 context of a charm. Below is the list of observed events for `jenkins-k8s charm` with how the charm
 reacts to the event. For more information about the charm’s lifecycle in general, refer to the
-charm’s life [documentation](https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/hook/).
+charm’s life [documentation](https://canonical.com/juju/docs/juju-cli/3.6/reference/hook/).
 
 ### Event jenkins_pebble_ready
 
@@ -103,6 +103,6 @@ The `src/charm.py` is the default entry point for a charm and has the JenkinsK8s
 
 CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
 
-> See more in the Juju docs: [Charm](https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/charm/).
+> See more in the Juju docs: [Charm](https://canonical.com/juju/docs/juju-cli/3.6/reference/charm/).
 
 The `__init__` method guarantees that the charm observes all events relevant to its operation and handles them.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Update to latest migrated juju documentation links
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
