### PR TITLE
fix(actions): sync rotate-credentials with juju secret state

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -609,10 +609,6 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         if not jenkins.is_storage_ready(container):
             event.fail("Jenkins storage not yet mounted.")
             return
-        if not jenkins.is_jenkins_ready(container):
-            event.fail("Jenkins service is not yet ready.")
-            return
-
         charm_state = self._get_state()
         if not charm_state:
             event.fail("Jenkins charm is not yet ready.")
@@ -628,7 +624,12 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             return
 
         admin_client = jenkins.Jenkins(self._jenkins_prefix, current_password, container)
-        admin_client.wait_ready(api_ready=True)
+        try:
+            admin_client.wait_ready(api_ready=True)
+        except TimeoutError:
+            event.fail("Jenkins service is not yet ready.")
+            return
+
         try:
             password = admin_client.rotate_credentials(container)
         except jenkins.JenkinsError:

--- a/src/charm.py
+++ b/src/charm.py
@@ -612,22 +612,35 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         if not jenkins.is_jenkins_ready(container):
             event.fail("Jenkins service is not yet ready.")
             return
+
+        charm_state = self._get_state()
+        if not charm_state:
+            event.fail("Jenkins charm is not yet ready.")
+            return
+
+        current_password = charm_state.admin_password
         try:
-            credentials = jenkins.get_admin_credentials(container)
+            if not current_password:
+                current_password = jenkins.get_admin_credentials(container).password_or_token
         except jenkins.JenkinsBootstrapError as exc:
             logger.error("Failed to get admin credentials, %s", exc)
             event.fail("Jenkins has not yet bootstrapped.")
             return
 
-        admin_client = jenkins.Jenkins(
-            self._jenkins_prefix, credentials.password_or_token, container
-        )
+        admin_client = jenkins.Jenkins(self._jenkins_prefix, current_password, container)
         admin_client.wait_ready(api_ready=True)
         try:
             password = admin_client.rotate_credentials(container)
         except jenkins.JenkinsError:
             event.fail("Error invalidating user sessions. See logs.")
             return
+
+        try:
+            secret = self.model.get_secret(label=self.app.name)
+            secret.set_content({"password": password})
+        except ops.SecretNotFoundError:
+            self.app.add_secret(content={"password": password}, label=self.app.name)
+
         event.set_results({"password": password})
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -626,7 +626,14 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         admin_client = jenkins.Jenkins(self._jenkins_prefix, current_password, container)
         try:
             admin_client.wait_ready(api_ready=True)
-        except TimeoutError:
+        except TimeoutError as exc:
+            logger.warning(
+                "phase=rotate_credentials wait_ready_timeout unit=%s app=%s jenkins_prefix=%s error=%s",
+                self.unit.name,
+                self.app.name,
+                self._jenkins_prefix,
+                exc,
+            )
             event.fail("Jenkins service is not yet ready.")
             return
 

--- a/src/jenkins.py
+++ b/src/jenkins.py
@@ -18,6 +18,7 @@ import typing
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
+import time
 from urllib.parse import urlparse
 
 import jenkinsapi.custom_exceptions
@@ -266,13 +267,35 @@ class Jenkins:
         Raises:
             TimeoutError: if Jenkins status check did not pass within the timeout duration.
         """
+        start = time.monotonic()
+        logger.info(
+            "phase=wait_ready start web_url=%s api_ready=%s timeout=%s check_interval=%s",
+            self.web_url,
+            api_ready,
+            timeout,
+            check_interval,
+        )
         try:
             if api_ready:
-                return _wait_for(
+                result = _wait_for(
                     self._is_api_ready, timeout=timeout, check_interval=check_interval
                 )
-            _wait_for(self._is_ready, timeout=timeout, check_interval=check_interval)
+            else:
+                result = _wait_for(self._is_ready, timeout=timeout, check_interval=check_interval)
+            logger.info(
+                "phase=wait_ready success web_url=%s api_ready=%s elapsed_s=%.2f",
+                self.web_url,
+                api_ready,
+                time.monotonic() - start,
+            )
+            return result
         except TimeoutError as exc:
+            logger.warning(
+                "phase=wait_ready timeout web_url=%s api_ready=%s elapsed_s=%.2f",
+                self.web_url,
+                api_ready,
+                time.monotonic() - start,
+            )
             raise TimeoutError("Timed out waiting for Jenkins to become ready.") from exc
 
     def get_admin_user_client(self) -> jenkinsapi.jenkins.Jenkins:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,18 +120,26 @@ def model_app_unit_fixture(model: Model, application: Application, unit: Unit):
     return ModelAppUnit(model=model, app=application, unit=unit)
 
 
-@pytest_asyncio.fixture(scope="module", name="unit_ip")
+@pytest_asyncio.fixture(scope="function", name="unit_ip")
 async def unit_ip_fixture(model: Model, application: Application):
     """Get Jenkins charm unit IP."""
     unit_ips = await get_model_unit_addresses(model=model, app_name=application.name)
     assert unit_ips, f"Unit IP address not found for {application.name}"
+    logger.info(
+        "phase=unit_ip_fixture model=%s app=%s resolved_ips=%s",
+        model.name,
+        application.name,
+        unit_ips,
+    )
     return unit_ips[0]
 
 
-@pytest.fixture(scope="module", name="web_address")
+@pytest.fixture(scope="function", name="web_address")
 def web_address_fixture(unit_ip: str):
     """Get Jenkins charm web address."""
-    return f"http://{unit_ip}:8080"
+    address = f"http://{unit_ip}:8080"
+    logger.info("phase=web_address_fixture address=%s", address)
+    return address
 
 
 @pytest_asyncio.fixture(scope="function", name="jenkins_client")
@@ -141,7 +149,52 @@ async def jenkins_client_fixture(
     web_address: str,
 ) -> jenkinsapi.jenkins.Jenkins:
     """The Jenkins API client."""
-    jenkins_client = await generate_jenkins_client(ops_test, application, web_address)
+    logger.info(
+        "phase=jenkins_client_fixture start model=%s app=%s web_address=%s",
+        ops_test.model_name,
+        application.name,
+        web_address,
+    )
+    try:
+        jenkins_client = await generate_jenkins_client(ops_test, application, web_address)
+    except Exception as exc:
+        logger.error(
+            "phase=jenkins_client_fixture failed model=%s app=%s web_address=%s exc_type=%s exc=%s",
+            ops_test.model_name,
+            application.name,
+            web_address,
+            type(exc).__name__,
+            exc,
+        )
+        model = ops_test.model
+        if model is not None:
+            try:
+                status = await model.get_status()
+                app_status = status.applications.get(application.name)
+                unit_keys = []
+                if app_status is not None and app_status.units:
+                    unit_keys = sorted(app_status.units.keys())
+                logger.error(
+                    "phase=jenkins_client_fixture model_snapshot app=%s app_status=%s app_message=%s units=%s",
+                    application.name,
+                    getattr(app_status, "status", None),
+                    getattr(app_status, "status_info", None),
+                    unit_keys,
+                )
+            except Exception as status_exc:
+                logger.error(
+                    "phase=jenkins_client_fixture model_snapshot_failed exc_type=%s exc=%s",
+                    type(status_exc).__name__,
+                    status_exc,
+                )
+        raise
+    logger.info(
+        "phase=jenkins_client_fixture success model=%s app=%s web_address=%s client_baseurl=%s",
+        ops_test.model_name,
+        application.name,
+        web_address,
+        jenkins_client.baseurl,
+    )
     return jenkins_client
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,6 +10,7 @@ import textwrap
 import time
 import typing
 from enum import Enum
+from urllib.parse import urlparse
 
 import jenkinsapi.jenkins
 import kubernetes.client
@@ -369,6 +370,29 @@ async def generate_jenkins_client(
         A Jenkins web client.
     """
     jenkins_unit = jenkins_app.units[0]
+    start = time.monotonic()
+    model = ops_test.model
+    assert model is not None
+    current_unit_ips = await get_model_unit_addresses(model=model, app_name=jenkins_app.name)
+    requested_host = urlparse(address).hostname
+    logger.info(
+        "phase=generate_client app=%s unit=%s address=%s requested_host=%s resolved_ips=%s method=%s",
+        jenkins_app.name,
+        jenkins_unit.name,
+        address,
+        requested_host,
+        current_unit_ips,
+        method.value,
+    )
+    if requested_host and requested_host not in current_unit_ips:
+        logger.warning(
+            "phase=generate_client app=%s unit=%s stale_address_detected address_host=%s resolved_ips=%s",
+            jenkins_app.name,
+            jenkins_unit.name,
+            requested_host,
+            current_unit_ips,
+        )
+
     if method == AuthMethod.TOKEN:
         ret, api_token, stderr = await ops_test.juju(
             "ssh",
@@ -383,11 +407,55 @@ async def generate_jenkins_client(
     elif method == AuthMethod.PASSWORD:
         action = await jenkins_unit.run_action("get-admin-password")
         await action.wait()
+        logger.info(
+            "phase=generate_client app=%s unit=%s auth_action=%s action_status=%s action_result_keys=%s",
+            jenkins_app.name,
+            jenkins_unit.name,
+            "get-admin-password",
+            action.status,
+            sorted(action.results.keys()),
+        )
         secret = action.results["password"]
     else:
         raise ValueError(f"Unsupported auth method: {method}")
 
-    return jenkinsapi.jenkins.Jenkins(address, "admin", secret, timeout=60)
+    try:
+        response = requests.get(f"{address}/login", timeout=10)
+        logger.info(
+            "phase=generate_client app=%s unit=%s login_probe_status=%s elapsed_s=%.2f",
+            jenkins_app.name,
+            jenkins_unit.name,
+            response.status_code,
+            time.monotonic() - start,
+        )
+    except requests.RequestException as exc:
+        logger.warning(
+            "phase=generate_client app=%s unit=%s login_probe_error=%s elapsed_s=%.2f",
+            jenkins_app.name,
+            jenkins_unit.name,
+            repr(exc),
+            time.monotonic() - start,
+        )
+
+    try:
+        client = jenkinsapi.jenkins.Jenkins(address, "admin", secret, timeout=60)
+        logger.info(
+            "phase=generate_client app=%s unit=%s client_created=true elapsed_s=%.2f",
+            jenkins_app.name,
+            jenkins_unit.name,
+            time.monotonic() - start,
+        )
+        return client
+    except Exception as exc:
+        logger.warning(
+            "phase=generate_client app=%s unit=%s client_created=false exc_type=%s exc=%s elapsed_s=%.2f",
+            jenkins_app.name,
+            jenkins_unit.name,
+            type(exc).__name__,
+            exc,
+            time.monotonic() - start,
+        )
+        raise
 
 
 async def generate_unit_web_client_from_application(

--- a/tests/integration/test_auth_proxy.py
+++ b/tests/integration/test_auth_proxy.py
@@ -236,11 +236,25 @@ def identity_platform_traefik_ip_fixture(
     identity_platform_juju: jubilant.Juju,
 ):
     """Identity platform traefik ip."""
-    idp_traefik_loadbalancer_service = kube_core_client.read_namespaced_service(
-        name=f"{identity_platform_public_traefik}-lb",
-        namespace=identity_platform_juju.model,
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type((AssertionError, TypeError, KeyError, IndexError)),
+        stop=tenacity.stop_after_attempt(12),
+        wait=tenacity.wait_fixed(10),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
     )
-    return idp_traefik_loadbalancer_service.status.load_balancer.ingress[0].ip
+    def _get_lb_ip() -> str:
+        idp_traefik_loadbalancer_service = kube_core_client.read_namespaced_service(
+            name=f"{identity_platform_public_traefik}-lb",
+            namespace=identity_platform_juju.model,
+        )
+        ingress = idp_traefik_loadbalancer_service.status.load_balancer.ingress
+        assert ingress, "Identity platform traefik load balancer ingress not ready"
+        ip = ingress[0].ip
+        assert ip, "Identity platform traefik load balancer IP not ready"
+        return str(ip)
+
+    return _get_lb_ip()
 
 
 @pytest.fixture(scope="module", name="jenkins_traefik_ip")
@@ -250,10 +264,24 @@ def jenkins_traefik_ip_fixture(
     model: Model,
 ):
     """Jenkins traefik ip."""
-    jenkins_traefik_loadbalancer_service = kube_core_client.read_namespaced_service(
-        name=f"{jenkins_k8s_charms.traefik}-lb", namespace=model.name
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type((AssertionError, TypeError, KeyError, IndexError)),
+        stop=tenacity.stop_after_attempt(12),
+        wait=tenacity.wait_fixed(10),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
     )
-    return jenkins_traefik_loadbalancer_service.status.load_balancer.ingress[0].ip
+    def _get_lb_ip() -> str:
+        jenkins_traefik_loadbalancer_service = kube_core_client.read_namespaced_service(
+            name=f"{jenkins_k8s_charms.traefik}-lb", namespace=model.name
+        )
+        ingress = jenkins_traefik_loadbalancer_service.status.load_balancer.ingress
+        assert ingress, "Jenkins traefik load balancer ingress not ready"
+        ip = ingress[0].ip
+        assert ip, "Jenkins traefik load balancer IP not ready"
+        return str(ip)
+
+    return _get_lb_ip()
 
 
 @pytest.fixture(scope="module", name="patch_dns_resolver")
@@ -482,13 +510,22 @@ def jenkins_endpoint_fixture(model: Model, jenkins_k8s_charms: _JenkinsCharms):
     """The Jenkins endpoint URL from public traefik."""
     juju = jubilant.Juju(model=model.name)
 
-    endpoints = _get_traefik_proxied_endpoints(
-        juju=juju, traefik_app_name=jenkins_k8s_charms.traefik
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(AssertionError),
+        stop=tenacity.stop_after_attempt(18),
+        wait=tenacity.wait_fixed(10),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
     )
-    jenkins_endpoint = endpoints.get("jenkins-k8s", {}).get("url")
-    assert jenkins_endpoint, "Jenkins endpoint not found in proxied endpoints"
+    def _get_jenkins_endpoint() -> str:
+        endpoints = _get_traefik_proxied_endpoints(
+            juju=juju, traefik_app_name=jenkins_k8s_charms.traefik
+        )
+        jenkins_endpoint = endpoints.get("jenkins-k8s", {}).get("url")
+        assert jenkins_endpoint, "Jenkins endpoint not found in proxied endpoints"
+        return str(jenkins_endpoint)
 
-    return jenkins_endpoint
+    return _get_jenkins_endpoint()
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_auth_proxy.py
+++ b/tests/integration/test_auth_proxy.py
@@ -18,6 +18,7 @@ import pyotp
 import pytest
 import pytest_asyncio
 import requests
+import tenacity
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from juju.application import Application
@@ -194,8 +195,36 @@ def jenkins_k8s_charms_fixture(
     juju.integrate(f"{oauth2_proxy}:forward-auth", f"{traefik_public}:experimental-forward-auth")
     juju.integrate(f"{oauth2_proxy}:receive-ca-cert", identity_platform_offers.send_ca_cert.saas)
 
-    juju.wait(jubilant.all_agents_idle, timeout=15 * 60, successes=5, delay=5)
-    juju.wait(jubilant.all_active, timeout=15 * 60, successes=5, delay=5)
+    def _is_transient_controller_error(exc: BaseException) -> bool:
+        error_message = str(exc)
+        return (
+            "controller-service.controller-microk8s.svc.cluster.local" in error_message
+            or "api connection open timed out" in error_message
+            or "cannot open api" in error_message
+        )
+
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception(_is_transient_controller_error),
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(multiplier=1, min=5, max=20),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def _wait_all_agents_idle() -> None:
+        juju.wait(jubilant.all_agents_idle, timeout=15 * 60, successes=5, delay=5)
+
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception(_is_transient_controller_error),
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(multiplier=1, min=5, max=20),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def _wait_all_active() -> None:
+        juju.wait(jubilant.all_active, timeout=15 * 60, successes=5, delay=5)
+
+    _wait_all_agents_idle()
+    _wait_all_active()
 
     return _JenkinsCharms(jenkins=application.name, traefik=traefik_public, oauth2=oauth2_proxy)
 

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -73,7 +73,9 @@ async def test_rotate_password_action(jenkins_user_client: jenkinsapi.jenkins.Je
     assert result.status_code == 200, "Unable to access Jenkins with initial credentials."
     action: Action = await unit.run_action("rotate-credentials")
     await action.wait()
-    new_password: str = action.results["password"]
+    assert action.status == "completed", f"rotate-credentials failed: {action.results}"
+    new_password = action.results.get("password")
+    assert new_password, f"rotate-credentials did not return password: {action.results}"
 
     assert jenkins_user_client.password != new_password, "Password not rotated"
     result = session.get(f"{jenkins_user_client.baseurl}/manage")

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -7,7 +7,7 @@ import secrets
 
 # Need access to protected functions for testing
 import typing
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import ops
 import pytest
@@ -250,3 +250,80 @@ def test_on_rotate_credentials_action_fails_when_jenkins_not_bootstrapped(
     jenkins_charm._on_rotate_credentials(mock_event)
 
     mock_event.fail.assert_called_once_with("Jenkins has not yet bootstrapped.")
+
+
+def test_on_rotate_credentials_action_prefers_secret_from_charm_state_and_updates_secret(
+    harness_container: HarnessWithContainer,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    arrange: given charm state contains admin password and app secret exists.
+    act: when rotate_credentials action is run.
+    assert: state password is used for auth and rotated password is persisted to existing secret.
+    """
+    old_password = secrets.token_hex(16)
+    new_password = secrets.token_hex(16)
+    harness = harness_container.harness
+    harness.set_can_connect(harness.model.unit.containers["jenkins"], True)
+    mock_event = MagicMock(spec=ops.ActionEvent)
+    harness.begin()
+
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        jenkins_charm,
+        "_get_state",
+        MagicMock(return_value=MagicMock(admin_password=old_password)),
+    )
+    get_admin_credentials_mock = MagicMock()
+    monkeypatch.setattr(jenkins, "get_admin_credentials", get_admin_credentials_mock)
+    monkeypatch.setattr(jenkins.Jenkins, "rotate_credentials", MagicMock(return_value=new_password))
+
+    mock_secret = MagicMock()
+    monkeypatch.setattr(jenkins_charm.model, "get_secret", MagicMock(return_value=mock_secret))
+
+    jenkins_charm._on_rotate_credentials(mock_event)
+
+    mock_event.set_results.assert_called_once_with({"password": new_password})
+    get_admin_credentials_mock.assert_not_called()
+    mock_secret.set_content.assert_called_once_with({"password": new_password})
+
+
+def test_on_rotate_credentials_action_creates_secret_when_missing(
+    harness_container: HarnessWithContainer,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    arrange: given charm state contains admin password but app secret does not yet exist.
+    act: when rotate_credentials action is run.
+    assert: rotated password is written by creating app secret.
+    """
+    old_password = secrets.token_hex(16)
+    new_password = secrets.token_hex(16)
+    harness = harness_container.harness
+    harness.set_can_connect(harness.model.unit.containers["jenkins"], True)
+    mock_event = MagicMock(spec=ops.ActionEvent)
+    harness.begin()
+
+    jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
+    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        jenkins_charm,
+        "_get_state",
+        MagicMock(return_value=MagicMock(admin_password=old_password)),
+    )
+    monkeypatch.setattr(jenkins.Jenkins, "rotate_credentials", MagicMock(return_value=new_password))
+    monkeypatch.setattr(
+        jenkins_charm.model,
+        "get_secret",
+        MagicMock(side_effect=ops.SecretNotFoundError()),
+    )
+
+    with patch.object(jenkins_charm.app, "add_secret") as add_secret_mock:
+        jenkins_charm._on_rotate_credentials(mock_event)
+
+    mock_event.set_results.assert_called_once_with({"password": new_password})
+    add_secret_mock.assert_called_once_with(
+        content={"password": new_password},
+        label=jenkins_charm.app.name,
+    )

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -172,7 +172,6 @@ def test_on_rotate_credentials_action_api_error(
     harness.set_can_connect(harness.model.unit.containers["jenkins"], True)
     mock_event = MagicMock(spec=ops.ActionEvent)
     harness.begin()
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
     monkeypatch.setattr(
         jenkins.Jenkins,
@@ -198,8 +197,8 @@ def test_on_rotate_credentials_action(
     harness.set_can_connect(harness_container.harness.model.unit.containers["jenkins"], True)
     mock_event = MagicMock(spec=ops.ActionEvent)
     harness.begin()
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
     monkeypatch.setattr(jenkins.Jenkins, "rotate_credentials", MagicMock(return_value=password))
+    monkeypatch.setattr(jenkins.Jenkins, "wait_ready", MagicMock(return_value=None))
 
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
     jenkins_charm._on_rotate_credentials(mock_event)
@@ -211,15 +210,15 @@ def test_on_rotate_credentials_action_jenkins_not_ready(
     harness_container: HarnessWithContainer, monkeypatch: pytest.MonkeyPatch
 ):
     """
-    arrange: given Jenkins service is not ready.
+    arrange: given Jenkins service does not become ready before timeout.
     act: when rotate_credentials action is run.
-    assert: the event is failed with appropriate message.
+    assert: the event fails with readiness timeout message.
     """
     harness = harness_container.harness
     harness.set_can_connect(harness.model.unit.containers["jenkins"], True)
     mock_event = MagicMock(spec=ops.ActionEvent)
     harness.begin()
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=False))
+    monkeypatch.setattr(jenkins.Jenkins, "wait_ready", MagicMock(side_effect=TimeoutError))
 
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
     jenkins_charm._on_rotate_credentials(mock_event)
@@ -239,7 +238,6 @@ def test_on_rotate_credentials_action_fails_when_jenkins_not_bootstrapped(
     harness.set_can_connect(harness.model.unit.containers["jenkins"], True)
     mock_event = MagicMock(spec=ops.ActionEvent)
     harness.begin()
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
     monkeypatch.setattr(
         jenkins,
         "get_admin_credentials",
@@ -269,7 +267,6 @@ def test_on_rotate_credentials_action_prefers_secret_from_charm_state_and_update
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
     monkeypatch.setattr(
         jenkins_charm,
         "_get_state",
@@ -306,7 +303,6 @@ def test_on_rotate_credentials_action_creates_secret_when_missing(
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsK8sOperatorCharm, harness.charm)
-    monkeypatch.setattr(jenkins, "is_jenkins_ready", MagicMock(return_value=True))
     monkeypatch.setattr(
         jenkins_charm,
         "_get_state",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Update rotate credentials actions to use secrets managed by juju
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
