### PR TITLE
fix(metrics): include ingress prefix in Prometheus metrics_path

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -105,9 +105,13 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
             self,
             jobs=[
                 {
-                    "metrics_path": "/prometheus",
+                    "metrics_path": f"{self._get_ingress_path()}/prometheus",
                     "static_configs": [{"targets": [f"*:{jenkins.WEB_PORT}"]}],
                 }
+            ],
+            refresh_event=[
+                self.server_ingress.on.ready,
+                self.server_ingress.on.revoked,
             ],
         )
         self._grafana = GrafanaDashboardProvider(self)

--- a/tests/unit/test_metrics_endpoint.py
+++ b/tests/unit/test_metrics_endpoint.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the MetricsEndpointProvider configuration on the Jenkins charm."""
+
+from unittest.mock import PropertyMock
+
+import pytest
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops.testing import Harness
+
+from charm import JenkinsK8sOperatorCharm
+
+
+def test_metrics_path_without_ingress(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: a charm with no ingress URL set (url returns None).
+    act: read the metrics_path on the prometheus scrape job.
+    assert: the metrics_path is "/prometheus" (no prefix).
+    """
+    monkeypatch.setattr(IngressPerAppRequirer, "url", PropertyMock(return_value=None))
+    harness = Harness(JenkinsK8sOperatorCharm)
+    harness.add_network("10.0.0.10")
+    harness.begin()
+    try:
+        assert _scrape_metrics_path(harness) == "/prometheus"
+    finally:
+        harness.cleanup()
+
+
+def test_metrics_path_with_root_ingress(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: a charm with an ingress URL whose path is "/".
+    act: read the metrics_path on the prometheus scrape job.
+    assert: the metrics_path is "/prometheus" (no prefix, because "/" collapses to "").
+    """
+    monkeypatch.setattr(
+        IngressPerAppRequirer,
+        "url",
+        PropertyMock(return_value="https://host:8080/"),
+    )
+    harness = Harness(JenkinsK8sOperatorCharm)
+    harness.add_network("10.0.0.10")
+    harness.begin()
+    try:
+        assert _scrape_metrics_path(harness) == "/prometheus"
+    finally:
+        harness.cleanup()
+
+
+def test_metrics_path_with_ingress_prefix(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: a charm with an ingress URL that has a non-root path.
+    act: read the metrics_path on the prometheus scrape job.
+    assert: the metrics_path is "<ingress-path>/prometheus".
+    """
+    monkeypatch.setattr(
+        IngressPerAppRequirer,
+        "url",
+        PropertyMock(return_value="https://host:8080/model-jenkins-0"),
+    )
+    harness = Harness(JenkinsK8sOperatorCharm)
+    harness.add_network("10.0.0.10")
+    harness.begin()
+    try:
+        assert _scrape_metrics_path(harness) == "/model-jenkins-0/prometheus"
+    finally:
+        harness.cleanup()
+
+
+def _scrape_metrics_path(harness: Harness) -> str:
+    """Return the metrics_path on the first scrape job published by the charm."""
+    jobs = harness.charm._prometheus._jobs  # pylint: disable=protected-access
+    assert jobs, "Expected at least one scrape job to be configured."
+    return jobs[0]["metrics_path"]


### PR DESCRIPTION
## Summary

When Jenkins is served behind an ingress, it listens at `<prefix>/prometheus` rather than `/prometheus`. The MetricsEndpointProvider previously hardcoded metrics_path to `/prometheus`, so Prometheus scraping the pod IP directly received 404s.

## Changes

- Prepend `_get_ingress_path()` to metrics_path so it becomes `/model-jenkins-0/prometheus` when Jenkins is behind an ingress
- Add server_ingress ready/revoked events to refresh_event so the scrape job spec is re-published when ingress arrives or departs after the metrics-endpoint relation is already established
- Add comprehensive unit tests covering all three scenarios: no ingress, ingress at root, ingress with path prefix

## Tests

All unit tests pass (265 total, including 3 new metrics endpoint tests):
- `test_metrics_path_without_ingress` — validates /prometheus path when no ingress
- `test_metrics_path_with_root_ingress` — validates /prometheus path when ingress at root /
- `test_metrics_path_with_ingress_prefix` — validates /model-jenkins-0/prometheus path when ingress has prefix

Lint and static security checks pass.

## Fixes

Closes #385