### PR TITLE
feat: expose jcasc related configurations as terraform variables

### DIFF
--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -33,9 +33,35 @@ module "jenkins-k8s" {
   source = "git::https://github.com/canonical/jenkins-k8s-operator//terraform"
 
   model = juju_model.my_model.name
-  # (Customize configuration variables here if needed)
+
+  # Charm configuration options (all optional; unset options keep charm defaults).
+  # config = {
+  #   allowed_plugins   = "git,kubernetes,ldap"
+  #   system_properties = "jenkins.model.Jenkins.crumbIssuerProxyCompatibility=true"
+  #   jcasc_repository  = "https://github.com/my-org/my-jcasc"
+  # }
 }
 ```
+
+The `config` variable is a typed object whose attributes map directly to the
+charm configuration options in `charmcraft.yaml`:
+
+| Terraform attribute            | Charm config option            |
+| ------------------------------ | ------------------------------ |
+| `restart_time_range`           | `restart-time-range`           |
+| `allowed_plugins`              | `allowed-plugins`              |
+| `system_properties`            | `system-properties`            |
+| `jcasc_config`                 | `jcasc-config`                 |
+| `jcasc_repository`             | `jcasc-repository`             |
+| `jcasc_repository_token`       | `jcasc-repository-token`       |
+| `jcasc_repository_config_path` | `jcasc-repository-config-path` |
+| `jcasc_repository_branch`      | `jcasc-repository-branch`      |
+| `jcasc_environment_secrets`    | `jcasc-environment-secrets`    |
+
+The `jcasc_repository_token` and `jcasc_environment_secrets` options take a Juju
+user-secret URI. See
+[the configurations tab](https://charmhub.io/jenkins-k8s/configurations) for
+option semantics and defaults.
 
 Create integrations, for instance:
 

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -1,6 +1,25 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+locals {
+  # Map the typed config object attributes onto their charmcraft.yaml option
+  # names, then drop any attribute left unset so the charm-provided default
+  # applies instead of overriding it with an empty value.
+  config = {
+    for key, value in {
+      "restart-time-range"           = var.config.restart_time_range
+      "allowed-plugins"              = var.config.allowed_plugins
+      "system-properties"            = var.config.system_properties
+      "jcasc-config"                 = var.config.jcasc_config
+      "jcasc-repository"             = var.config.jcasc_repository
+      "jcasc-repository-token"       = var.config.jcasc_repository_token
+      "jcasc-repository-config-path" = var.config.jcasc_repository_config_path
+      "jcasc-repository-branch"      = var.config.jcasc_repository_branch
+      "jcasc-environment-secrets"    = var.config.jcasc_environment_secrets
+    } : key => value if value != null
+  }
+}
+
 resource "juju_application" "jenkins_k8s" {
   name  = var.app_name
   model = var.model
@@ -12,7 +31,7 @@ resource "juju_application" "jenkins_k8s" {
     base     = var.base
   }
 
-  config      = var.config
+  config      = local.config
   constraints = var.constraints
   units       = 1
 }

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -14,9 +14,46 @@ variable "channel" {
 }
 
 variable "config" {
-  description = "Application config. Details about available options can be found at https://charmhub.io/jenkins-k8s/configurations"
-  type        = map(string)
-  default     = {}
+  description = <<-EOT
+    Application configuration options for the jenkins-k8s charm. Each attribute
+    maps to a charm config option defined in charmcraft.yaml. Unset attributes
+    fall back to the charm-provided default.
+
+    Details about available options can be found at
+    https://charmhub.io/jenkins-k8s/configurations
+
+    - restart_time_range: Preferred UTC time range in 24 hour format for
+      restarting Jenkins (e.g. "03-05"). If empty, restart happens whenever
+      Jenkins needs to restart.
+    - allowed_plugins: Comma-separated list of allowed plugin short names. If
+      empty, any plugin can be installed.
+    - system_properties: Comma-separated JVM system properties (key=value,
+      without the -D prefix) passed to the Jenkins process at startup.
+    - jcasc_config: Jenkins Configuration as Code (JCasC) YAML content. Mutually
+      exclusive with jcasc_repository.
+    - jcasc_repository: HTTPS URL of a public git repository containing JCasC
+      YAML files. Mutually exclusive with jcasc_config.
+    - jcasc_repository_token: A Juju user-secret URI granting access to a private
+      jcasc_repository. The secret must contain `username` and `token` keys.
+    - jcasc_repository_config_path: Path to the directory within
+      jcasc_repository containing YAML files. Defaults to "jcasc".
+    - jcasc_repository_branch: Git branch to check out when cloning
+      jcasc_repository. Defaults to "main".
+    - jcasc_environment_secrets: A Juju user-secret URI containing key-value
+      pairs to inject as environment variables for JCasC interpolation.
+  EOT
+  type = object({
+    restart_time_range           = optional(string)
+    allowed_plugins              = optional(string)
+    system_properties            = optional(string)
+    jcasc_config                 = optional(string)
+    jcasc_repository             = optional(string)
+    jcasc_repository_token       = optional(string)
+    jcasc_repository_config_path = optional(string)
+    jcasc_repository_branch      = optional(string)
+    jcasc_environment_secrets    = optional(string)
+  })
+  default = {}
 }
 
 variable "constraints" {

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -21,9 +21,19 @@ variable "jenkins_agent_k8s" {
 
 variable "jenkins_k8s" {
   type = object({
-    app_name    = optional(string, "jenkins-k8s")
-    channel     = optional(string, "latest/stable")
-    config      = optional(map(string), {})
+    app_name = optional(string, "jenkins-k8s")
+    channel  = optional(string, "latest/stable")
+    config = optional(object({
+      restart_time_range           = optional(string)
+      allowed_plugins              = optional(string)
+      system_properties            = optional(string)
+      jcasc_config                 = optional(string)
+      jcasc_repository             = optional(string)
+      jcasc_repository_token       = optional(string)
+      jcasc_repository_config_path = optional(string)
+      jcasc_repository_branch      = optional(string)
+      jcasc_environment_secrets    = optional(string)
+    }), {})
     constraints = optional(string, "")
     revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Exposes JCasC charm configuration values terraform variables
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://canonical.com/juju/docs/ops/latest/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
