### PR TITLE
fix(ci): grant permissions for auto_update_libs reusable workflow

### DIFF
--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -7,4 +7,8 @@ on:
 jobs:
   auto-update-libs:
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
## Summary
- add explicit permissions to `.github/workflows/auto_update_libs.yaml`
- grant `contents: write`, `pull-requests: write`, and `id-token: write` to the reusable-workflow caller job

## Why
The auto-update libraries workflow has a long startup-failure streak (61 runs).  
Latest failed run: https://github.com/canonical/jenkins-k8s-operator/actions/runs/29711267046

This repository uses read-only default workflow token permissions, but the called reusable workflow requires write scopes.

## Resolution
Add explicit caller permissions so scheduled runs can start and create update PRs successfully.