### PR TITLE
fix: no plugin deletion

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -451,9 +451,15 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         ):
             return
 
+        # An empty (unset) allowed-plugins configuration disables allowlist cleanup,
+        # permitting any plugin to be installed. Skip removal to avoid uninstalling
+        # user-installed plugins.
+        if state.plugins is None:
+            return
+
         try:
             admin_client.remove_unlisted_plugins(
-                plugins=itertools.chain(state.plugins or [], REQUIRED_PLUGINS),
+                plugins=itertools.chain(state.plugins, REQUIRED_PLUGINS),
                 container=container,
             )
         except (jenkins.JenkinsPluginError, jenkins.JenkinsError) as exc:

--- a/tests/unit/test_charm_plugins.py
+++ b/tests/unit/test_charm_plugins.py
@@ -80,6 +80,24 @@ def test__reconcile_plugins_calls_remove_unlisted_plugins(
     assert call_kwargs["container"] is harness_container.container
 
 
+def test__reconcile_plugins_skips_when_no_allowlist(
+    harness_container: HarnessWithContainer,
+):
+    """
+    arrange: given an unset (empty) allowed-plugins config so state.plugins is None.
+    act: when _reconcile_plugins is called.
+    assert: remove_unlisted_plugins is not called, leaving installed plugins intact.
+    """
+    harness_container.harness.begin()
+    charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
+    admin_client = MagicMock(spec=jenkins.Jenkins)
+    charm_state = _make_state(plugins=None)
+
+    charm._reconcile_plugins(charm_state, admin_client, harness_container.container)
+
+    admin_client.remove_unlisted_plugins.assert_not_called()
+
+
 def test__reconcile_plugins_skips_outside_restart_window(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://canonical.com/juju/docs/ops/latest/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
