### PR TITLE
fix: allow all plugins behavior regrssion fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-23
+
+- Fix plugin reconciliation to skip plugin removal when `plugins` is unset or empty.
+
 ## 2026-07-08
 
 - Add `jcasc-environment-secrets` charm configuration option to inject Juju secrets as environment variables for JCasC interpolation; secret rotation triggers automatic charm reconciliation.

--- a/src/charm.py
+++ b/src/charm.py
@@ -451,6 +451,9 @@ class JenkinsK8sOperatorCharm(ops.CharmBase):
         ):
             return
 
+        if not state.plugins:
+            return
+
         try:
             admin_client.remove_unlisted_plugins(
                 plugins=itertools.chain(state.plugins or [], REQUIRED_PLUGINS),

--- a/tests/unit/test_charm_plugins.py
+++ b/tests/unit/test_charm_plugins.py
@@ -80,6 +80,32 @@ def test__reconcile_plugins_calls_remove_unlisted_plugins(
     assert call_kwargs["container"] is harness_container.container
 
 
+@pytest.mark.parametrize(
+    "plugins",
+    [
+        pytest.param(None, id="plugins-undefined"),
+        pytest.param([], id="plugins-empty"),
+    ],
+)
+def test__reconcile_plugins_skips_when_plugins_not_defined(
+    harness_container: HarnessWithContainer,
+    plugins: list[str] | None,
+):
+    """
+    arrange: given plugins are not configured.
+    act: when _reconcile_plugins is called.
+    assert: remove_unlisted_plugins is not called.
+    """
+    harness_container.harness.begin()
+    charm = typing.cast(JenkinsK8sOperatorCharm, harness_container.harness.charm)
+    admin_client = MagicMock(spec=jenkins.Jenkins)
+    charm_state = _make_state(plugins=plugins)
+
+    charm._reconcile_plugins(charm_state, admin_client, harness_container.container)
+
+    admin_client.remove_unlisted_plugins.assert_not_called()
+
+
 def test__reconcile_plugins_skips_outside_restart_window(
     harness_container: HarnessWithContainer,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fixes regression for plugins delete no-op when `allowed-plugins` configuration value is set explicitly to empty string "".

<!-- A high level overview of the change -->

### Rationale

Regression during refactor.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://canonical.com/juju/docs/ops/latest/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
